### PR TITLE
Use splitmix

### DIFF
--- a/GameDefinition/game-src/TieKnot.hs
+++ b/GameDefinition/game-src/TieKnot.hs
@@ -13,7 +13,7 @@ import           Control.Concurrent.Async
 import qualified Control.Exception as Ex
 import qualified Data.Primitive.PrimArray as PA
 import           GHC.Compact
-import qualified System.Random as R
+import qualified System.Random.SplitMix32 as SM
 
 import           Game.LambdaHack.Client
 import qualified Game.LambdaHack.Client.UI.Content.Input as IC
@@ -62,7 +62,7 @@ tieKnotForAsync options@ServerOptions{ sallClear
   -- This setup ensures the boosting option doesn't affect generating initial
   -- RNG for dungeon, etc., and also, that setting dungeon RNG on commandline
   -- equal to what was generated last time, ensures the same item boost.
-  initialGen <- maybe R.getStdGen return sdungeonRng
+  initialGen <- maybe SM.newSMGen return sdungeonRng
   let soptionsNxt = options {sdungeonRng = Just initialGen}
       boostedItems = IK.boostItemKindList initialGen Content.ItemKind.items
       coitem = IK.makeData $

--- a/LambdaHack.cabal
+++ b/LambdaHack.cabal
@@ -193,6 +193,7 @@ library definition
                       ,keys
                       ,miniutter
                       ,random
+                      ,splitmix
                       ,time
                       ,text
                       ,transformers
@@ -348,6 +349,7 @@ library
                       pretty-show >= 1.6,
                       primitive  >= 0.6.1.0,
                       random     >= 1.1,
+                      splitmix   >= 0.0.3,
                       stm        >= 2.4,
                       time       >= 1.4,
                       text       >= 0.11.2.3,
@@ -426,6 +428,7 @@ library this-game-src
                       ,optparse-applicative
                       ,primitive
                       ,random
+                      ,splitmix
                       ,template-haskell >= 2.6
                       ,text
                       ,transformers

--- a/LambdaHack.cabal
+++ b/LambdaHack.cabal
@@ -91,10 +91,11 @@ flag gtk
   default:            False
   manual:             True
 
-flag sdl
-  description:        switch to the SDL2 frontend
-  default:            False
-  manual:             True
+-- This flag is not used.
+-- flag sdl
+--   description:        switch to the SDL2 frontend
+--   default:            False
+--   manual:             True
 
 flag jsaddle
   description:        switch to the JSaddle frontend (may be bit-rotted)
@@ -362,15 +363,15 @@ library
     exposed-modules:    Game.LambdaHack.Client.UI.Frontend.Dom
     build-depends:    ghcjs-dom >= 0.9.1.1
     cpp-options:      -DUSE_BROWSER
-  } else { if flag(vty) {
+  } elif flag(vty) {
     exposed-modules:    Game.LambdaHack.Client.UI.Frontend.Vty
     build-depends:    vty >= 5
     cpp-options:      -DUSE_VTY
-  } else { if flag(curses) {
+  } elif flag(curses) {
     exposed-modules:    Game.LambdaHack.Client.UI.Frontend.Curses
     build-depends:    hscurses >= 1.4.1
     cpp-options:      -DUSE_CURSES
-  } else { if flag(gtk) {
+  } elif flag(gtk) {
     exposed-modules:    Game.LambdaHack.Client.UI.Frontend.Gtk
     build-depends:    gtk3 >= 0.12.1
     cpp-options:      -DUSE_GTK
@@ -378,7 +379,7 @@ library
     exposed-modules:    Game.LambdaHack.Client.UI.Frontend.Sdl
     build-depends:    sdl2 >= 2, sdl2-ttf >= 2
     cpp-options:      -DUSE_SDL
-  } } } }
+  }
 
   if impl(ghcjs) {
     other-modules:    Game.LambdaHack.Common.JSFile

--- a/LambdaHack.cabal.flattened
+++ b/LambdaHack.cabal.flattened
@@ -333,6 +333,7 @@ library
                       pretty-show >= 1.6,
                       primitive  >= 0.6.1.0,
                       random     >= 1.1,
+                      splitmix   >= 0.0.3,
                       stm        >= 2.4,
                       time       >= 1.4,
                       text       >= 0.11.2.3,

--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,9 @@ benchFrontendBattle:
 benchCrawl:
 	dist/build/LambdaHack/LambdaHack --dbgMsgSer --logPriority 4 --newGame 1 --noAnim --maxFps 100000 --frontendNull --benchmark --stopAfterFrames 7000 --automateAll --keepAutomated --gameMode crawl --setDungeonRng 0 --setMainRng 0
 
+benchCrawl-new-build:
+	$$(cabal-plan list-bin LambdaHack) --dbgMsgSer --logPriority 4 --newGame 1 --noAnim --maxFps 100000 --frontendNull --benchmark --stopAfterFrames 7000 --automateAll --keepAutomated --gameMode crawl --setDungeonRng "SMGen 123 123" --setMainRng "SMGen 125 125"
+
 benchFrontendCrawl:
 	dist/build/LambdaHack/LambdaHack --dbgMsgSer --logPriority 4 --newGame 1 --noAnim --maxFps 100000 --benchmark --stopAfterFrames 7000 --automateAll --keepAutomated --gameMode crawl --setDungeonRng 0 --setMainRng 0
 
@@ -131,6 +134,13 @@ nodeBenchCrawl:
 
 nodeBenchBattle:
 	node dist/build/LambdaHack/LambdaHack.jsexe/all.js --dbgMsgSer --logPriority 4 --newGame 3 --noAnim --maxFps 100000 --frontendNull --benchmark --stopAfterFrames 1000 --automateAll --keepAutomated --gameMode battle --setDungeonRng 0 --setMainRng 0
+
+# needs installed cabal-plan
+nodeBenchCrawl-new-build:
+	node $$(cabal-plan list-bin LambdaHack).jsexe/all.js --dbgMsgSer --logPriority 4 --newGame 3 --noAnim --maxFps 100000 --frontendNull --benchmark --stopAfterFrames 1000 --automateAll --keepAutomated --gameMode crawl --setDungeonRng "SMGen 123 123" --setMainRng "SMGen 123 125"
+
+nodeBenchBattle-new-build:
+	node $$(cabal-plan list-bin LambdaHack).jsexe/all.js --dbgMsgSer --logPriority 4 --newGame 3 --noAnim --maxFps 100000 --frontendNull --benchmark --stopAfterFrames 1000 --automateAll --keepAutomated --gameMode battle --setDungeonRng "SMGen 123 123" --setMainRng "SMGen 123 125"
 
 nodeBench: nodeBenchBattle nodeBenchCrawl
 

--- a/Makefile
+++ b/Makefile
@@ -92,55 +92,59 @@ frontendDefenseEmpty:
 fastCrawl:
 	dist/build/LambdaHack/LambdaHack --dbgMsgSer --logPriority 4 --savePrefix test --newGame 1 --dumpInitRngs --automateAll --gameMode crawl --exposeItems --exposeActors --showItemSamples --noAnim --maxFps 100000
 
+# different benchmarks use(d) different arguments
+RNGOPTS=--setDungeonRng "SMGen 123 123" --setMainRng "SMGen 125 125"
+RNGOPTS1=--setDungeonRng "SMGen 127 123" --setMainRng "SMGen 125 125"
+RNGOPTS2=--setDungeonRng "SMGen 129 123" --setMainRng "SMGen 125 125"
 
 benchMemoryAnim:
-	dist/build/LambdaHack/LambdaHack --dbgMsgSer --logPriority 4 --newGame 1 --maxFps 100000 --benchmark --stopAfterFrames 33000 --automateAll --keepAutomated --gameMode crawl --setDungeonRng 120 --setMainRng 47 --frontendNull --noAnim +RTS -s -A1M -RTS
+	dist/build/LambdaHack/LambdaHack --dbgMsgSer --logPriority 4 --newGame 1 --maxFps 100000 --benchmark --stopAfterFrames 33000 --automateAll --keepAutomated --gameMode crawl $(RNGOPTS2)  --frontendNull --noAnim +RTS -s -A1M -RTS
 
 benchBattle:
-	dist/build/LambdaHack/LambdaHack --dbgMsgSer --logPriority 4 --newGame 3 --noAnim --maxFps 100000 --frontendNull --benchmark --stopAfterFrames 1500 --automateAll --keepAutomated --gameMode battle --setDungeonRng 7 --setMainRng 7
+	dist/build/LambdaHack/LambdaHack --dbgMsgSer --logPriority 4 --newGame 3 --noAnim --maxFps 100000 --frontendNull --benchmark --stopAfterFrames 1500 --automateAll --keepAutomated --gameMode battle $(RNGOPTS1)
 
 benchAnimBattle:
-	dist/build/LambdaHack/LambdaHack --dbgMsgSer --logPriority 4 --newGame 3 --maxFps 100000 --frontendNull --benchmark --stopAfterFrames 7000 --automateAll --keepAutomated --gameMode battle --setDungeonRng 7 --setMainRng 7
+	dist/build/LambdaHack/LambdaHack --dbgMsgSer --logPriority 4 --newGame 3 --maxFps 100000 --frontendNull --benchmark --stopAfterFrames 7000 --automateAll --keepAutomated --gameMode battle $(RNGOPTS1)
 
 benchFrontendBattle:
-	dist/build/LambdaHack/LambdaHack --dbgMsgSer --logPriority 4 --newGame 3 --noAnim --maxFps 100000 --benchmark --stopAfterFrames 2000 --automateAll --keepAutomated --gameMode battle --setDungeonRng 7 --setMainRng 7
+	dist/build/LambdaHack/LambdaHack --dbgMsgSer --logPriority 4 --newGame 3 --noAnim --maxFps 100000 --benchmark --stopAfterFrames 2000 --automateAll --keepAutomated --gameMode battle $(RNGOPTS1)
 
 benchCrawl:
-	dist/build/LambdaHack/LambdaHack --dbgMsgSer --logPriority 4 --newGame 1 --noAnim --maxFps 100000 --frontendNull --benchmark --stopAfterFrames 7000 --automateAll --keepAutomated --gameMode crawl --setDungeonRng 0 --setMainRng 0
+	dist/build/LambdaHack/LambdaHack --dbgMsgSer --logPriority 4 --newGame 1 --noAnim --maxFps 100000 --frontendNull --benchmark --stopAfterFrames 7000 --automateAll --keepAutomated --gameMode crawl $(RNGOPTS)
 
 benchCrawl-new-build:
-	$$(cabal-plan list-bin LambdaHack) --dbgMsgSer --logPriority 4 --newGame 1 --noAnim --maxFps 100000 --frontendNull --benchmark --stopAfterFrames 7000 --automateAll --keepAutomated --gameMode crawl --setDungeonRng "SMGen 123 123" --setMainRng "SMGen 125 125"
+	$$(cabal-plan list-bin LambdaHack) --dbgMsgSer --logPriority 4 --newGame 1 --noAnim --maxFps 100000 --frontendNull --benchmark --stopAfterFrames 7000 --automateAll --keepAutomated --gameMode crawl $(RNGOPTS)
 
 benchFrontendCrawl:
-	dist/build/LambdaHack/LambdaHack --dbgMsgSer --logPriority 4 --newGame 1 --noAnim --maxFps 100000 --benchmark --stopAfterFrames 7000 --automateAll --keepAutomated --gameMode crawl --setDungeonRng 0 --setMainRng 0
+	dist/build/LambdaHack/LambdaHack --dbgMsgSer --logPriority 4 --newGame 1 --noAnim --maxFps 100000 --benchmark --stopAfterFrames 7000 --automateAll --keepAutomated --gameMode crawl $(RNGOPTS)
 
 benchDig:
-	dist/build/LambdaHack/LambdaHack --dbgMsgSer --logPriority 4 --newGame 1 --noAnim --maxFps 100000 --frontendNull --benchmark --stopAfterFrames 1 --automateAll --keepAutomated --gameMode dig --setDungeonRng 0 --setMainRng 0
+	dist/build/LambdaHack/LambdaHack --dbgMsgSer --logPriority 4 --newGame 1 --noAnim --maxFps 100000 --frontendNull --benchmark --stopAfterFrames 1 --automateAll --keepAutomated --gameMode dig $(RNGOPTS)
 
 benchNull: benchBattle benchAnimBattle benchCrawl
 
 bench: benchBattle benchAnimBattle benchFrontendBattle benchCrawl benchFrontendCrawl
 
 nativeBenchCrawl:
-	dist/build/LambdaHack/LambdaHack		   --dbgMsgSer --logPriority 4 --newGame 1 --noAnim --maxFps 100000 --frontendNull --benchmark --stopAfterFrames 2000 --automateAll --keepAutomated --gameMode crawl --setDungeonRng 0 --setMainRng 0
+	dist/build/LambdaHack/LambdaHack		   --dbgMsgSer --logPriority 4 --newGame 1 --noAnim --maxFps 100000 --frontendNull --benchmark --stopAfterFrames 2000 --automateAll --keepAutomated --gameMode crawl $(RNGOPTS)
 
 nativeBenchBattle:
-	dist/build/LambdaHack/LambdaHack		   --dbgMsgSer --logPriority 4 --newGame 3 --noAnim --maxFps 100000 --frontendNull --benchmark --stopAfterFrames 1000 --automateAll --keepAutomated --gameMode battle --setDungeonRng 0 --setMainRng 0
+	dist/build/LambdaHack/LambdaHack		   --dbgMsgSer --logPriority 4 --newGame 3 --noAnim --maxFps 100000 --frontendNull --benchmark --stopAfterFrames 1000 --automateAll --keepAutomated --gameMode battle $(RNGOPTS)
 
 nativeBench: nativeBenchBattle nativeBenchCrawl
 
 nodeBenchCrawl:
-	node dist/build/LambdaHack/LambdaHack.jsexe/all.js --dbgMsgSer --logPriority 4 --newGame 1 --noAnim --maxFps 100000 --frontendNull --benchmark --stopAfterFrames 2000 --automateAll --keepAutomated --gameMode crawl --setDungeonRng 0 --setMainRng 0
+	node dist/build/LambdaHack/LambdaHack.jsexe/all.js --dbgMsgSer --logPriority 4 --newGame 1 --noAnim --maxFps 100000 --frontendNull --benchmark --stopAfterFrames 2000 --automateAll --keepAutomated --gameMode crawl $(RNGOPTS)
 
 nodeBenchBattle:
-	node dist/build/LambdaHack/LambdaHack.jsexe/all.js --dbgMsgSer --logPriority 4 --newGame 3 --noAnim --maxFps 100000 --frontendNull --benchmark --stopAfterFrames 1000 --automateAll --keepAutomated --gameMode battle --setDungeonRng 0 --setMainRng 0
+	node dist/build/LambdaHack/LambdaHack.jsexe/all.js --dbgMsgSer --logPriority 4 --newGame 3 --noAnim --maxFps 100000 --frontendNull --benchmark --stopAfterFrames 1000 --automateAll --keepAutomated --gameMode battle $(RNGOPTS)
 
 # needs installed cabal-plan
 nodeBenchCrawl-new-build:
-	node $$(cabal-plan list-bin LambdaHack).jsexe/all.js --dbgMsgSer --logPriority 4 --newGame 3 --noAnim --maxFps 100000 --frontendNull --benchmark --stopAfterFrames 1000 --automateAll --keepAutomated --gameMode crawl --setDungeonRng "SMGen 123 123" --setMainRng "SMGen 123 125"
+	node $$(cabal-plan list-bin LambdaHack).jsexe/all.js --dbgMsgSer --logPriority 4 --newGame 3 --noAnim --maxFps 100000 --frontendNull --benchmark --stopAfterFrames 1000 --automateAll --keepAutomated --gameMode crawl $(RNGOPTS)
 
 nodeBenchBattle-new-build:
-	node $$(cabal-plan list-bin LambdaHack).jsexe/all.js --dbgMsgSer --logPriority 4 --newGame 3 --noAnim --maxFps 100000 --frontendNull --benchmark --stopAfterFrames 1000 --automateAll --keepAutomated --gameMode battle --setDungeonRng "SMGen 123 123" --setMainRng "SMGen 123 125"
+	node $$(cabal-plan list-bin LambdaHack).jsexe/all.js --dbgMsgSer --logPriority 4 --newGame 3 --noAnim --maxFps 100000 --frontendNull --benchmark --stopAfterFrames 1000 --automateAll --keepAutomated --gameMode battle $(RNGOPTS)
 
 nodeBench: nodeBenchBattle nodeBenchCrawl
 
@@ -231,22 +235,22 @@ test-short-new:
 	dist/build/LambdaHack/LambdaHack --dbgMsgSer --logPriority 4 --boostRandomItem --newGame 5 --savePrefix battleDefense --dumpInitRngs --automateAll --keepAutomated --gameMode "battle defense" --frontendTeletype --stopAfterSeconds 2 2> /tmp/teletypetest.log
 	dist/build/LambdaHack/LambdaHack --dbgMsgSer --logPriority 4 --boostRandomItem --newGame 5 --savePrefix battleSurvival --dumpInitRngs --automateAll --keepAutomated --gameMode "battle survival" --frontendTeletype --stopAfterSeconds 2 2> /tmp/teletypetest.log
 
-# "--setDungeonRng 0 --setMainRng 0" is needed for determinism relative to seed
+# $(RNGOPTS) is needed for determinism relative to seed
 # generated before game save
 test-short-load:
-	dist/build/LambdaHack/LambdaHack --dbgMsgSer --logPriority 4 --boostRandomItem --savePrefix raid --dumpInitRngs --automateAll --keepAutomated --gameMode raid --frontendTeletype --stopAfterSeconds 2 --setDungeonRng 0 --setMainRng 0 2> /tmp/teletypetest.log
-	dist/build/LambdaHack/LambdaHack --dbgMsgSer --logPriority 4 --boostRandomItem --savePrefix brawl --dumpInitRngs --automateAll --keepAutomated --gameMode brawl --frontendTeletype --stopAfterSeconds 2 --setDungeonRng 0 --setMainRng 0 2> /tmp/teletypetest.log
-	dist/build/LambdaHack/LambdaHack --dbgMsgSer --logPriority 4 --boostRandomItem --savePrefix shootout --dumpInitRngs --automateAll --keepAutomated --gameMode shootout --frontendTeletype --stopAfterSeconds 2 --setDungeonRng 0 --setMainRng 0 2> /tmp/teletypetest.log
-	dist/build/LambdaHack/LambdaHack --dbgMsgSer --logPriority 4 --boostRandomItem --savePrefix hunt --dumpInitRngs --automateAll --keepAutomated --gameMode hunt --frontendTeletype --stopAfterSeconds 2 --setDungeonRng 0 --setMainRng 0 2> /tmp/teletypetest.log
-	dist/build/LambdaHack/LambdaHack --dbgMsgSer --logPriority 4 --boostRandomItem --savePrefix escape --dumpInitRngs --automateAll --keepAutomated --gameMode escape --frontendTeletype --stopAfterSeconds 2 --setDungeonRng 0 --setMainRng 0 2> /tmp/teletypetest.log
-	dist/build/LambdaHack/LambdaHack --dbgMsgSer --logPriority 4 --boostRandomItem --savePrefix zoo --dumpInitRngs --automateAll --keepAutomated --gameMode zoo --frontendTeletype --stopAfterSeconds 2 --setDungeonRng 0 --setMainRng 0 2> /tmp/teletypetest.log
-	dist/build/LambdaHack/LambdaHack --dbgMsgSer --logPriority 4 --boostRandomItem --savePrefix ambush --dumpInitRngs --automateAll --keepAutomated --gameMode ambush --frontendTeletype --stopAfterSeconds 2 --setDungeonRng 0 --setMainRng 0 2> /tmp/teletypetest.log
-	dist/build/LambdaHack/LambdaHack --dbgMsgSer --logPriority 4 --boostRandomItem --savePrefix crawl --dumpInitRngs --automateAll --keepAutomated --gameMode crawl --frontendTeletype --stopAfterSeconds 2 --setDungeonRng 0 --setMainRng 0 2> /tmp/teletypetest.log
-	dist/build/LambdaHack/LambdaHack --dbgMsgSer --logPriority 4 --boostRandomItem --savePrefix safari --dumpInitRngs --automateAll --keepAutomated --gameMode safari --frontendTeletype --stopAfterSeconds 2 --setDungeonRng 0 --setMainRng 0 2> /tmp/teletypetest.log
-	dist/build/LambdaHack/LambdaHack --dbgMsgSer --logPriority 4 --boostRandomItem --savePrefix safariSurvival --dumpInitRngs --automateAll --keepAutomated --gameMode "safari survival" --frontendTeletype --stopAfterSeconds 2 --setDungeonRng 0 --setMainRng 0 2> /tmp/teletypetest.log
-	dist/build/LambdaHack/LambdaHack --dbgMsgSer --logPriority 4 --boostRandomItem --savePrefix battle --dumpInitRngs --automateAll --keepAutomated --gameMode battle --frontendTeletype --stopAfterSeconds 2 --setDungeonRng 0 --setMainRng 0 2> /tmp/teletypetest.log
-	dist/build/LambdaHack/LambdaHack --dbgMsgSer --logPriority 4 --boostRandomItem --savePrefix battleDefense --dumpInitRngs --automateAll --keepAutomated --gameMode "battle defense" --frontendTeletype --stopAfterSeconds 2 --setDungeonRng 0 --setMainRng 0 2> /tmp/teletypetest.log
-	dist/build/LambdaHack/LambdaHack --dbgMsgSer --logPriority 4 --boostRandomItem --savePrefix battleSurvival --dumpInitRngs --automateAll --keepAutomated --gameMode "battle survival" --frontendTeletype --stopAfterSeconds 2 --setDungeonRng 0 --setMainRng 0 2> /tmp/teletypetest.log
+	dist/build/LambdaHack/LambdaHack --dbgMsgSer --logPriority 4 --boostRandomItem --savePrefix raid --dumpInitRngs --automateAll --keepAutomated --gameMode raid --frontendTeletype --stopAfterSeconds 2 $(RNGOPTS) 2> /tmp/teletypetest.log
+	dist/build/LambdaHack/LambdaHack --dbgMsgSer --logPriority 4 --boostRandomItem --savePrefix brawl --dumpInitRngs --automateAll --keepAutomated --gameMode brawl --frontendTeletype --stopAfterSeconds 2 $(RNGOPTS) 2> /tmp/teletypetest.log
+	dist/build/LambdaHack/LambdaHack --dbgMsgSer --logPriority 4 --boostRandomItem --savePrefix shootout --dumpInitRngs --automateAll --keepAutomated --gameMode shootout --frontendTeletype --stopAfterSeconds 2 $(RNGOPTS) 2> /tmp/teletypetest.log
+	dist/build/LambdaHack/LambdaHack --dbgMsgSer --logPriority 4 --boostRandomItem --savePrefix hunt --dumpInitRngs --automateAll --keepAutomated --gameMode hunt --frontendTeletype --stopAfterSeconds 2 $(RNGOPTS) 2> /tmp/teletypetest.log
+	dist/build/LambdaHack/LambdaHack --dbgMsgSer --logPriority 4 --boostRandomItem --savePrefix escape --dumpInitRngs --automateAll --keepAutomated --gameMode escape --frontendTeletype --stopAfterSeconds 2 $(RNGOPTS) 2> /tmp/teletypetest.log
+	dist/build/LambdaHack/LambdaHack --dbgMsgSer --logPriority 4 --boostRandomItem --savePrefix zoo --dumpInitRngs --automateAll --keepAutomated --gameMode zoo --frontendTeletype --stopAfterSeconds 2 $(RNGOPTS) 2> /tmp/teletypetest.log
+	dist/build/LambdaHack/LambdaHack --dbgMsgSer --logPriority 4 --boostRandomItem --savePrefix ambush --dumpInitRngs --automateAll --keepAutomated --gameMode ambush --frontendTeletype --stopAfterSeconds 2 $(RNGOPTS) 2> /tmp/teletypetest.log
+	dist/build/LambdaHack/LambdaHack --dbgMsgSer --logPriority 4 --boostRandomItem --savePrefix crawl --dumpInitRngs --automateAll --keepAutomated --gameMode crawl --frontendTeletype --stopAfterSeconds 2 $(RNGOPTS) 2> /tmp/teletypetest.log
+	dist/build/LambdaHack/LambdaHack --dbgMsgSer --logPriority 4 --boostRandomItem --savePrefix safari --dumpInitRngs --automateAll --keepAutomated --gameMode safari --frontendTeletype --stopAfterSeconds 2 $(RNGOPTS) 2> /tmp/teletypetest.log
+	dist/build/LambdaHack/LambdaHack --dbgMsgSer --logPriority 4 --boostRandomItem --savePrefix safariSurvival --dumpInitRngs --automateAll --keepAutomated --gameMode "safari survival" --frontendTeletype --stopAfterSeconds 2 $(RNGOPTS) 2> /tmp/teletypetest.log
+	dist/build/LambdaHack/LambdaHack --dbgMsgSer --logPriority 4 --boostRandomItem --savePrefix battle --dumpInitRngs --automateAll --keepAutomated --gameMode battle --frontendTeletype --stopAfterSeconds 2 $(RNGOPTS) 2> /tmp/teletypetest.log
+	dist/build/LambdaHack/LambdaHack --dbgMsgSer --logPriority 4 --boostRandomItem --savePrefix battleDefense --dumpInitRngs --automateAll --keepAutomated --gameMode "battle defense" --frontendTeletype --stopAfterSeconds 2 $(RNGOPTS) 2> /tmp/teletypetest.log
+	dist/build/LambdaHack/LambdaHack --dbgMsgSer --logPriority 4 --boostRandomItem --savePrefix battleSurvival --dumpInitRngs --automateAll --keepAutomated --gameMode "battle survival" --frontendTeletype --stopAfterSeconds 2 $(RNGOPTS) 2> /tmp/teletypetest.log
 
 
 build-binary-common:

--- a/definition-src/Game/LambdaHack/Content/ItemKind.hs
+++ b/definition-src/Game/LambdaHack/Content/ItemKind.hs
@@ -23,10 +23,10 @@ import           Data.Binary
 import           Data.Hashable (Hashable)
 import qualified Data.Text as T
 import           GHC.Generics (Generic)
-import qualified System.Random as R
 import qualified System.Random.SplitMix32 as SM
 
 import qualified Game.LambdaHack.Core.Dice as Dice
+import           Game.LambdaHack.Core.Random (randomR0)
 import qualified Game.LambdaHack.Definition.Ability as Ability
 import           Game.LambdaHack.Definition.ContentData
 import           Game.LambdaHack.Definition.Defs
@@ -192,7 +192,7 @@ instance Hashable ThrowMod
 boostItemKindList :: SM.SMGen -> [ItemKind] -> [ItemKind]
 boostItemKindList _ [] = []
 boostItemKindList initialGen l =
-  let (r, _) = R.randomR (0, length l - 1) initialGen
+  let (r, _) = randomR0 (length l - 1) initialGen
   in case splitAt r l of
     (pre, i : post) -> pre ++ boostItemKind i : post
     _               -> error $  "" `showFailure` l

--- a/definition-src/Game/LambdaHack/Content/ItemKind.hs
+++ b/definition-src/Game/LambdaHack/Content/ItemKind.hs
@@ -24,6 +24,7 @@ import           Data.Hashable (Hashable)
 import qualified Data.Text as T
 import           GHC.Generics (Generic)
 import qualified System.Random as R
+import qualified System.Random.SplitMix32 as SM
 
 import qualified Game.LambdaHack.Core.Dice as Dice
 import qualified Game.LambdaHack.Definition.Ability as Ability
@@ -188,7 +189,7 @@ instance Binary ThrowMod
 
 instance Hashable ThrowMod
 
-boostItemKindList :: R.StdGen -> [ItemKind] -> [ItemKind]
+boostItemKindList :: SM.SMGen -> [ItemKind] -> [ItemKind]
 boostItemKindList _ [] = []
 boostItemKindList initialGen l =
   let (r, _) = R.randomR (0, length l - 1) initialGen

--- a/definition-src/Game/LambdaHack/Core/Random.hs
+++ b/definition-src/Game/LambdaHack/Core/Random.hs
@@ -23,12 +23,13 @@ import Game.LambdaHack.Core.Prelude
 import qualified Control.Monad.Trans.State.Strict as St
 import           Data.Ratio
 import qualified System.Random as R
+import qualified System.Random.SplitMix32 as SM
 
 import qualified Game.LambdaHack.Core.Dice as Dice
 import           Game.LambdaHack.Core.Frequency
 
 -- | The monad of computations with random generator state.
-type Rnd a = St.State R.StdGen a
+type Rnd a = St.State SM.SMGen a
 
 -- | Get a random object within a range with a uniform distribution.
 randomR :: (R.Random a) => (a, a) -> Rnd a
@@ -61,7 +62,7 @@ frequency :: Show a => Frequency a -> Rnd a
 frequency = St.state . rollFreq
 
 -- | Randomly choose an item according to the distribution.
-rollFreq :: Show a => Frequency a -> R.StdGen -> (a, R.StdGen)
+rollFreq :: Show a => Frequency a -> SM.SMGen -> (a, SM.SMGen)
 rollFreq fr g = case runFrequency fr of
   [] -> error $ "choice from an empty frequency"
                 `showFailure` nameFrequency fr

--- a/engine-src/Game/LambdaHack/Atomic/CmdAtomic.hs
+++ b/engine-src/Game/LambdaHack/Atomic/CmdAtomic.hs
@@ -21,7 +21,7 @@ import Prelude ()
 import Game.LambdaHack.Core.Prelude
 
 import           Data.Int (Int64)
-import qualified System.Random as R
+import qualified System.Random.SplitMix32 as SM
 
 -- Dependence on ClientOptions is an anomaly. Instead, probably the raw
 -- remaining commandline should be passed and parsed by the client to extract
@@ -124,7 +124,7 @@ data UpdAtomic =
   | UpdDiscoverServer ItemId IA.AspectRecord
   | UpdCoverServer ItemId IA.AspectRecord
   | UpdPerception LevelId Perception Perception
-  | UpdRestart FactionId PerLid State Challenge ClientOptions R.StdGen
+  | UpdRestart FactionId PerLid State Challenge ClientOptions SM.SMGen
   | UpdRestartServer State
   | UpdResume FactionId PerLid
   | UpdResumeServer State

--- a/engine-src/Game/LambdaHack/Client/State.hs
+++ b/engine-src/Game/LambdaHack/Client/State.hs
@@ -17,7 +17,7 @@ import qualified Data.EnumSet as ES
 import qualified Data.Map.Strict as M
 import qualified Data.Primitive.PrimArray as PA
 import           GHC.Generics (Generic)
-import qualified System.Random as R
+import qualified System.Random.SplitMix32 as SM
 
 import           Game.LambdaHack.Client.Bfs
 import           Game.LambdaHack.Client.ClientOptions
@@ -53,7 +53,7 @@ data StateClient = StateClient
       --   but they are costly to generate and not too large
   , sfper         :: PerLid         -- ^ faction perception indexed by level
   , salter        :: AlterLid       -- ^ cached alter skill data for positions
-  , srandom       :: R.StdGen       -- ^ current random generator
+  , srandom       :: SM.SMGen       -- ^ current random generator
   , _sleader      :: Maybe ActorId  -- ^ candidate new leader of the faction;
                                     --   Faction.gleader is the old leader
   , _sside        :: FactionId      -- ^ faction controlled by the client
@@ -129,7 +129,7 @@ emptyStateClient _sside =
     , sdiscoBenefit = EM.empty
     , sfper = EM.empty
     , salter = EM.empty
-    , srandom = R.mkStdGen 42  -- will get modified in this and future games
+    , srandom = SM.mkSMGen 42  -- will get modified in this and future games
     , _sleader = Nothing  -- no heroes yet alive
     , _sside
     , squit = False

--- a/engine-src/Game/LambdaHack/Client/UI/Animation.hs
+++ b/engine-src/Game/LambdaHack/Client/UI/Animation.hs
@@ -233,7 +233,7 @@ fadeout ScreenContent{rwidth, rheight} out step = do
               | otherwise = mnx
         in EM.findWithDefault ' ' k edge
       rollFrame !n = do
-        r <- random
+        r <- randomInt
         let fadeAttr !y !x = attrChar1ToW32 $ fadeChar r n x y
             fadeLine !y =
               let x1 :: Int

--- a/engine-src/Game/LambdaHack/Common/ItemAspect.hs
+++ b/engine-src/Game/LambdaHack/Common/ItemAspect.hs
@@ -22,7 +22,7 @@ import qualified Data.EnumSet as ES
 import           Data.Hashable (Hashable)
 import qualified Data.Text as T
 import           GHC.Generics (Generic)
-import qualified System.Random as R
+import qualified System.Random.SplitMix32 as SM
 
 import           Game.LambdaHack.Common.Point
 import           Game.LambdaHack.Common.Time
@@ -103,7 +103,7 @@ aspectsRandom ass =
   let rollM depth =
         foldlM' (castAspect (Dice.AbsDepth depth) (Dice.AbsDepth 10))
                 emptyAspectRecord ass
-      gen = R.mkStdGen 0
+      gen = SM.mkSMGen 0
       (ar0, gen0) = St.runState (rollM 0) gen
       (ar1, gen1) = St.runState (rollM 10) gen0
   in show gen /= show gen0 || show gen /= show gen1 || ar0 /= ar1

--- a/engine-src/Game/LambdaHack/Server/Commandline.hs
+++ b/engine-src/Game/LambdaHack/Server/Commandline.hs
@@ -18,7 +18,7 @@ import qualified Paths_LambdaHack as Self (version)
 import qualified Data.Text as T
 import           Data.Version
 import           Options.Applicative
-import qualified System.Random as R
+import qualified System.Random.SplitMix32 as SM
 
 -- Dependence on ClientOptions is an anomaly. Instead, probably the raw
 -- remaining commandline should be passed and parsed by the client to extract
@@ -204,13 +204,13 @@ benchmarkP =
   switch (  long "benchmark"
          <> help "Restrict file IO, print timing stats" )
 
-setDungeonRngP :: Parser (Maybe R.StdGen)
+setDungeonRngP :: Parser (Maybe SM.SMGen)
 setDungeonRngP = optional $
   option auto (  long "setDungeonRng"
               <> metavar "RNG_SEED"
               <> help "Set dungeon generation RNG seed to string RNG_SEED" )
 
-setMainRngP :: Parser (Maybe R.StdGen)
+setMainRngP :: Parser (Maybe SM.SMGen)
 setMainRngP = optional $
   option auto (  long "setMainRng"
               <> metavar "RNG_SEED"

--- a/engine-src/Game/LambdaHack/Server/DungeonGen.hs
+++ b/engine-src/Game/LambdaHack/Server/DungeonGen.hs
@@ -22,7 +22,6 @@ import qualified Data.Text as T
 import qualified Data.Text.IO as T
 import           System.IO (hFlush, stdout)
 import           System.IO.Unsafe (unsafePerformIO)
-import qualified System.Random as R
 import qualified System.Random.SplitMix32 as SM
 
 import           Game.LambdaHack.Common.Area
@@ -65,7 +64,7 @@ convertTileMaps COps{corule=RuleContent{rXmax, rYmax}, cotile, coTileSpeedup}
                   in (tile, (gen2, (pI + 1, assocs)))
            else (outerId, (gen1, (pI + 1, assocs)))
       runUnfold gen =
-        let (gen1, gen2) = R.split gen
+        let (gen1, gen2) = SM.splitSMGen gen
         in (PointArray.unfoldrNA
               rXmax rYmax runCdefTile
               (gen1, (0, IM.assocs $ EM.enumMapToIntMap ltile)), gen2)

--- a/engine-src/Game/LambdaHack/Server/DungeonGen.hs
+++ b/engine-src/Game/LambdaHack/Server/DungeonGen.hs
@@ -23,6 +23,7 @@ import qualified Data.Text.IO as T
 import           System.IO (hFlush, stdout)
 import           System.IO.Unsafe (unsafePerformIO)
 import qualified System.Random as R
+import qualified System.Random.SplitMix32 as SM
 
 import           Game.LambdaHack.Common.Area
 import           Game.LambdaHack.Definition.Defs
@@ -52,9 +53,9 @@ convertTileMaps :: COps -> Bool -> Rnd (ContentId TileKind)
 convertTileMaps COps{corule=RuleContent{rXmax, rYmax}, cotile, coTileSpeedup}
                 areAllWalkable cdefTile mpickPassable darea ltile = do
   let outerId = ouniqGroup cotile "unknown outer fence"
-      runCdefTile :: (R.StdGen, (Int, [(Int, ContentId TileKind)]))
+      runCdefTile :: (SM.SMGen, (Int, [(Int, ContentId TileKind)]))
                   -> ( ContentId TileKind
-                     , (R.StdGen, (Int, [(Int, ContentId TileKind)])) )
+                     , (SM.SMGen, (Int, [(Int, ContentId TileKind)])) )
       runCdefTile (gen1, (pI, assocs)) =
         let p = toEnum pI
         in if p `inside` darea

--- a/engine-src/Game/LambdaHack/Server/MonadServer.hs
+++ b/engine-src/Game/LambdaHack/Server/MonadServer.hs
@@ -30,7 +30,6 @@ import           Data.Time.LocalTime
 import           System.Exit (exitFailure)
 import           System.FilePath
 import           System.IO (hFlush, stdout)
-import qualified System.Random as R
 import qualified System.Random.SplitMix32 as SM
 
 import           Game.LambdaHack.Atomic

--- a/engine-src/Game/LambdaHack/Server/MonadServer.hs
+++ b/engine-src/Game/LambdaHack/Server/MonadServer.hs
@@ -31,6 +31,7 @@ import           System.Exit (exitFailure)
 import           System.FilePath
 import           System.IO (hFlush, stdout)
 import qualified System.Random as R
+import qualified System.Random.SplitMix32 as SM
 
 import           Game.LambdaHack.Atomic
 import           Game.LambdaHack.Client (sbenchmark)
@@ -204,7 +205,7 @@ rndToAction r = do
 
 -- | Gets a random generator from the user-submitted options or, if not present,
 -- generates one.
-getSetGen :: MonadServer m => Maybe R.StdGen -> m R.StdGen
+getSetGen :: MonadServer m => Maybe SM.SMGen -> m SM.SMGen
 getSetGen mrng = case mrng of
   Just rnd -> return rnd
-  Nothing -> liftIO R.newStdGen
+  Nothing -> liftIO SM.newSMGen

--- a/engine-src/Game/LambdaHack/Server/ServerOptions.hs
+++ b/engine-src/Game/LambdaHack/Server/ServerOptions.hs
@@ -8,7 +8,7 @@ import Prelude ()
 import Game.LambdaHack.Core.Prelude
 
 import           Data.Binary
-import qualified System.Random as R
+import qualified System.Random.SplitMix32 as SM
 
 import Game.LambdaHack.Client (ClientOptions (..), defClientOptions)
 import Game.LambdaHack.Definition.Defs
@@ -26,8 +26,8 @@ data ServerOptions = ServerOptions
   , sgameMode        :: Maybe (GroupName ModeKind)
   , sautomateAll     :: Bool
   , skeepAutomated   :: Bool
-  , sdungeonRng      :: Maybe R.StdGen
-  , smainRng         :: Maybe R.StdGen
+  , sdungeonRng      :: Maybe SM.SMGen
+  , smainRng         :: Maybe SM.SMGen
   , snewGameSer      :: Bool
   , scurChalSer      :: Challenge
   , sdumpInitRngs    :: Bool
@@ -41,8 +41,8 @@ data ServerOptions = ServerOptions
   deriving Show
 
 data RNGs = RNGs
-  { dungeonRandomGenerator  :: Maybe R.StdGen
-  , startingRandomGenerator :: Maybe R.StdGen
+  { dungeonRandomGenerator  :: Maybe SM.SMGen
+  , startingRandomGenerator :: Maybe SM.SMGen
   }
 
 instance Show RNGs where

--- a/engine-src/Game/LambdaHack/Server/StartM.hs
+++ b/engine-src/Game/LambdaHack/Server/StartM.hs
@@ -24,6 +24,7 @@ import qualified Data.Text as T
 import           Data.Tuple (swap)
 import qualified NLP.Miniutter.English as MU
 import qualified System.Random as R
+import qualified System.Random.SplitMix32 as SM
 
 import           Game.LambdaHack.Atomic
 import           Game.LambdaHack.Common.ActorState
@@ -250,7 +251,7 @@ resetFactions factionDold gameModeIdOld curDiffSerOld totalDepth players = do
 
 gameReset :: MonadServer m
           => ServerOptions -> Maybe (GroupName ModeKind)
-          -> Maybe R.StdGen -> m State
+          -> Maybe SM.SMGen -> m State
 gameReset serverOptions mGameMode mrandom = do
   -- Dungeon seed generation has to come first, to ensure item boosting
   -- is determined by the dungeon RNG.

--- a/engine-src/Game/LambdaHack/Server/StartM.hs
+++ b/engine-src/Game/LambdaHack/Server/StartM.hs
@@ -23,7 +23,6 @@ import qualified Data.Set as S
 import qualified Data.Text as T
 import           Data.Tuple (swap)
 import qualified NLP.Miniutter.English as MU
-import qualified System.Random as R
 import qualified System.Random.SplitMix32 as SM
 
 import           Game.LambdaHack.Atomic
@@ -93,7 +92,7 @@ reinitGame = do
   mapWithKeyM_ (\fid _ -> do
     -- Different seed for each client, to make sure behaviour is varied.
     gen1 <- getsServer srandom
-    let (clientRandomSeed, gen2) = R.split gen1
+    let (clientRandomSeed, gen2) = SM.splitSMGen gen1
     modifyServer $ \ser -> ser {srandom = gen2}
     execUpdAtomic $ updRestart fid clientRandomSeed) factionD
   dungeon <- getsState sdungeon

--- a/engine-src/Game/LambdaHack/Server/State.hs
+++ b/engine-src/Game/LambdaHack/Server/State.hs
@@ -12,7 +12,7 @@ import           Data.Binary
 import qualified Data.EnumMap.Strict as EM
 import qualified Data.EnumSet as ES
 import qualified Data.HashMap.Strict as HM
-import qualified System.Random as R
+import qualified System.Random.SplitMix32 as SM
 
 import Game.LambdaHack.Common.Analytics
 import Game.LambdaHack.Common.Perception
@@ -56,7 +56,7 @@ data StateServer = StateServer
   , sfovLitLid    :: FovLitLid      -- ^ ambient light positions
   , sarenas       :: [LevelId]      -- ^ active arenas
   , svalidArenas  :: Bool           -- ^ whether active arenas valid
-  , srandom       :: R.StdGen       -- ^ current random generator
+  , srandom       :: SM.SMGen       -- ^ current random generator
   , srngs         :: RNGs           -- ^ initial random generators
   , sbreakLoop    :: Bool           -- ^ exit game loop after clip's end;
                                     --   usually no game save follows
@@ -103,7 +103,7 @@ emptyStateServer =
     , sfovLitLid = EM.empty
     , sarenas = []
     , svalidArenas = False
-    , srandom = R.mkStdGen 42
+    , srandom = SM.mkSMGen 42
     , srngs = RNGs { dungeonRandomGenerator = Nothing
                    , startingRandomGenerator = Nothing }
     , sbreakLoop = False


### PR DESCRIPTION
This is work-in-progress, proof-of-concept.

- I added few ways to run benchmarks using `cabal-plan` to find out the location of an executable artifact.

Surprisingly, it seems that using `random` `benchCrawl-new-build` is slower with splitmix:

```
splitmix: Session time: 3.189302774s; frames: 7008. Average clips per second: 4687.231366638506. Average FPS: 2197.345469088411.
random:  Session time: 2.990903836s; frames: 7002. Average clips per second: 5110.829648218753. Average FPS: 2341.0983381412866.
```

---

`random` has `getStdRnd` which returns global random generator. I replaced it with `newSMGen` which splits out of global splimix gen (which isn't exposed).

Maybe the culprit is https://hackage.haskell.org/package/random-1.1/docs/src/System.Random.html#randomIvalInteger as implementation of `randomR` which doesn't let `splitmix` to shine, yet it shouldn't be slower. I'm confused.