### PR TITLE
Closing nearby doors automatically

### DIFF
--- a/engine-src/Game/LambdaHack/Server/Commandline.hs
+++ b/engine-src/Game/LambdaHack/Server/Commandline.hs
@@ -24,7 +24,7 @@ import qualified System.Random as R
 -- remaining commandline should be passed and parsed by the client to extract
 -- client and ui options from and singnal an error if anything was left.
 
-import Game.LambdaHack.Client (ClientOptions (..), )
+import Game.LambdaHack.Client (ClientOptions (..))
 import Game.LambdaHack.Common.Faction
 import Game.LambdaHack.Content.ModeKind
 import Game.LambdaHack.Definition.Defs


### PR DESCRIPTION
Quick fix for #134.

It checks if any tile around a player character is closable. If it is and it is unique, then it closes it.