### PR TITLE
Closing nearby doors automatically, take 2

### DIFF
--- a/GameDefinition/game-src/Client/UI/Content/Input.hs
+++ b/GameDefinition/game-src/Client/UI/Content/Input.hs
@@ -4,7 +4,7 @@ module Client.UI.Content.Input
   ( standardKeysAndMouse
 #ifdef EXPOSE_INTERNAL
     -- * Internal operations
-  , closeDoorTriggers, applyTs
+  , applyTs
 #endif
   ) where
 
@@ -14,7 +14,6 @@ import Game.LambdaHack.Core.Prelude
 
 import           Game.LambdaHack.Client.UI.Content.Input
 import           Game.LambdaHack.Client.UI.HumanCmd
-import qualified Game.LambdaHack.Content.TileKind as TK
 import           Game.LambdaHack.Definition.Defs
 
 -- | Description of default key-command bindings.
@@ -95,7 +94,7 @@ standardKeysAndMouse = InputContentRaw $ map evalKeyDef $
           $ moveItemTriple [CGround, CStash] CEqp "item" False)
 
   -- Terrain exploration and modification
-  , ("M", ([CmdMove], "modify any admissible terrain", AlterDir []))
+  , ("M", ([CmdMove], "modify any admissible terrain", AlterDir))
   , ("=", ( [CmdMove], "select (or deselect) party member", SelectActor) )
   , ("_", ([CmdMove], "deselect (or select) all on the level", SelectNone))
   , ("semicolon", ( [CmdMove]
@@ -202,7 +201,7 @@ standardKeysAndMouse = InputContentRaw $ map evalKeyDef $
   , ("RightButtonRelease", mouseRMB)
   , ("C-LeftButtonRelease", replaceDesc "" mouseRMB)  -- Mac convention
   , ( "S-RightButtonRelease"
-    , ([CmdMouse], "modify terrain at pointer", AlterWithPointer []) )
+    , ([CmdMouse], "modify terrain at pointer", AlterWithPointer) )
   , ("MiddleButtonRelease", mouseMMB)
   , ("C-RightButtonRelease", replaceDesc "" mouseMMB)
   , ( "C-S-LeftButtonRelease",
@@ -259,22 +258,6 @@ standardKeysAndMouse = InputContentRaw $ map evalKeyDef $
                , XhairPointerEnemy ))
   ]
   ++ map defaultHeroSelect [0..9]
-
-closeDoorTriggers :: [TriggerTile]
-closeDoorTriggers =
-  [ TriggerTile { ttverb = "close"
-                , ttobject = "door"
-                , ttfeature = TK.CloseTo "closed vertical door Lit" }
-  , TriggerTile { ttverb = "close"
-                , ttobject = "door"
-                , ttfeature = TK.CloseTo "closed horizontal door Lit" }
-  , TriggerTile { ttverb = "close"
-                , ttobject = "door"
-                , ttfeature = TK.CloseTo "closed vertical door Dark" }
-  , TriggerTile { ttverb = "close"
-                , ttobject = "door"
-                , ttfeature = TK.CloseTo "closed horizontal door Dark" }
-  ]
 
 applyTs :: [TriggerItem]
 applyTs = [TriggerItem { tiverb = "trigger"

--- a/GameDefinition/game-src/Client/UI/Content/Input.hs
+++ b/GameDefinition/game-src/Client/UI/Content/Input.hs
@@ -76,7 +76,7 @@ standardKeysAndMouse = InputContentRaw $ map evalKeyDef $
   , ("/", ([CmdMinimal, CmdAim], "cycle crosshair among items", AimItem))
   , ("m", ( [CmdMinimal, CmdMove]
           , "modify door by closing it"
-          , AlterDir closeDoorTriggers ))
+          , CloseDir ))
   , ("%", ([CmdMinimal, CmdMeta], "yell/yawn and stop sleeping", Yell))
 
   -- Item menu, first part of item use commands

--- a/engine-src/Game/LambdaHack/Client/UI/HandleHumanM.hs
+++ b/engine-src/Game/LambdaHack/Client/UI/HandleHumanM.hs
@@ -87,9 +87,9 @@ cmdAction cmd = case cmd of
     <$> (ReqUITimed <$$> moveItemHuman cLegalRaw toCStore mverb auto)
   Project -> weaveJust <$> (ReqUITimed <$$> projectHuman)
   Apply -> weaveJust <$> (ReqUITimed <$$> applyHuman)
-  AlterDir ts -> weaveJust <$> (ReqUITimed <$$> alterDirHuman ts)
-  AlterWithPointer ts -> weaveJust
-                         <$> (ReqUITimed <$$> alterWithPointerHuman ts)
+  AlterDir -> weaveJust <$> (ReqUITimed <$$> alterDirHuman)
+  AlterWithPointer -> weaveJust
+                         <$> (ReqUITimed <$$> alterWithPointerHuman)
   CloseDir -> weaveJust <$> (ReqUITimed <$$> closeDirHuman)
   Help -> helpHuman cmdAction
   Hint -> hintHuman cmdAction

--- a/engine-src/Game/LambdaHack/Client/UI/HandleHumanM.hs
+++ b/engine-src/Game/LambdaHack/Client/UI/HandleHumanM.hs
@@ -90,6 +90,7 @@ cmdAction cmd = case cmd of
   AlterDir ts -> weaveJust <$> (ReqUITimed <$$> alterDirHuman ts)
   AlterWithPointer ts -> weaveJust
                          <$> (ReqUITimed <$$> alterWithPointerHuman ts)
+  CloseDir -> weaveJust <$> (ReqUITimed <$$> closeDirHuman)
   Help -> helpHuman cmdAction
   Hint -> hintHuman cmdAction
   ItemMenu -> itemMenuHuman cmdAction

--- a/engine-src/Game/LambdaHack/Client/UI/HumanCmd.hs
+++ b/engine-src/Game/LambdaHack/Client/UI/HumanCmd.hs
@@ -126,6 +126,7 @@ data HumanCmd =
   | Apply
   | AlterDir [TriggerTile]
   | AlterWithPointer [TriggerTile]
+  | CloseDir
   | Help
   | Hint
   | ItemMenu

--- a/engine-src/Game/LambdaHack/Client/UI/HumanCmd.hs
+++ b/engine-src/Game/LambdaHack/Client/UI/HumanCmd.hs
@@ -4,7 +4,7 @@ module Game.LambdaHack.Client.UI.HumanCmd
   ( CmdCategory(..), categoryDescription
   , CmdArea(..), areaDescription
   , CmdTriple, AimModeCmd(..), HumanCmd(..)
-  , TriggerItem(..), TriggerTile(..)
+  , TriggerItem(..)
   ) where
 
 import Prelude ()
@@ -17,7 +17,6 @@ import           GHC.Generics (Generic)
 import qualified NLP.Miniutter.English as MU
 
 import           Game.LambdaHack.Common.Vector
-import qualified Game.LambdaHack.Content.TileKind as TK
 import           Game.LambdaHack.Definition.Defs
 
 data CmdCategory =
@@ -124,8 +123,8 @@ data HumanCmd =
   | MoveItem [CStore] CStore (Maybe MU.Part) Bool
   | Project
   | Apply
-  | AlterDir [TriggerTile]
-  | AlterWithPointer [TriggerTile]
+  | AlterDir
+  | AlterWithPointer
   | CloseDir
   | Help
   | Hint
@@ -208,16 +207,3 @@ instance Read TriggerItem where
 instance NFData TriggerItem
 
 instance Binary TriggerItem
-
--- | Description of how tile altering is triggered and communicated
--- to the player.
-data TriggerTile =
-  TriggerTile {ttverb :: MU.Part, ttobject :: MU.Part, ttfeature :: TK.Feature}
-  deriving (Show, Eq, Ord, Generic)
-
-instance Read TriggerTile where
-  readsPrec = error $ "parsing of TriggerTile not implemented" `showFailure` ()
-
-instance NFData TriggerTile
-
-instance Binary TriggerTile

--- a/engine-src/Game/LambdaHack/Common/ReqFailure.hs
+++ b/engine-src/Game/LambdaHack/Common/ReqFailure.hs
@@ -48,7 +48,6 @@ data ReqFailure =
   | CloseClosed
   | CloseNothing
   | CloseNonClosable
-  | TileOpenClosed
   | WaitUnskilled
   | YellUnskilled
   | MoveItemUnskilled
@@ -103,7 +102,6 @@ impossibleReqFailure reqFailure = case reqFailure of
   CloseClosed -> False
   CloseNothing -> False
   CloseNonClosable -> False
-  TileOpenClosed -> True  -- tile is both closed and open
   WaitUnskilled -> False  -- unidentified skill items
   YellUnskilled -> False  -- unidentified skill items
   MoveItemUnskilled -> False  -- unidentified skill items
@@ -151,11 +149,10 @@ showReqFailure reqFailure = case reqFailure of
   AlterBlockActor -> "blocked by an actor"
   AlterBlockItem -> "jammed by an item"
   AlterNothing -> "wasting time on altering nothing"
-  CloseDistant -> "trying to close a distant position"
+  CloseDistant -> "trying to close a distant terrain"
   CloseClosed -> "already closed"
   CloseNothing -> "no adjacent terrain can be closed"
   CloseNonClosable -> "cannot be closed"
-  TileOpenClosed -> "trying to close tile being both open and closed"
   WaitUnskilled -> "too low wait stat"
   YellUnskilled -> "actors unskilled in waiting cannot yell/yawn"
   MoveItemUnskilled -> "too low item moving stat"

--- a/engine-src/Game/LambdaHack/Common/ReqFailure.hs
+++ b/engine-src/Game/LambdaHack/Common/ReqFailure.hs
@@ -47,6 +47,8 @@ data ReqFailure =
   | CloseDistant
   | CloseClosed
   | CloseNothing
+  | CloseNonClosable
+  | TileOpenClosed
   | WaitUnskilled
   | YellUnskilled
   | MoveItemUnskilled
@@ -100,6 +102,8 @@ impossibleReqFailure reqFailure = case reqFailure of
   CloseDistant -> False
   CloseClosed -> False
   CloseNothing -> False
+  CloseNonClosable -> False
+  TileOpenClosed -> True  -- tile is both closed and open
   WaitUnskilled -> False  -- unidentified skill items
   YellUnskilled -> False  -- unidentified skill items
   MoveItemUnskilled -> False  -- unidentified skill items
@@ -147,9 +151,11 @@ showReqFailure reqFailure = case reqFailure of
   AlterBlockActor -> "blocked by an actor"
   AlterBlockItem -> "jammed by an item"
   AlterNothing -> "wasting time on altering nothing"
-  CloseDistant -> "trying to close a dinstant object"
+  CloseDistant -> "trying to close a distant position"
   CloseClosed -> "already closed"
-  CloseNothing -> "wasting time on closing nothing"
+  CloseNothing -> "no adjacent terrain can be closed"
+  CloseNonClosable -> "cannot be closed"
+  TileOpenClosed -> "trying to close tile being both open and closed"
   WaitUnskilled -> "too low wait stat"
   YellUnskilled -> "actors unskilled in waiting cannot yell/yawn"
   MoveItemUnskilled -> "too low item moving stat"

--- a/engine-src/Game/LambdaHack/Common/ReqFailure.hs
+++ b/engine-src/Game/LambdaHack/Common/ReqFailure.hs
@@ -44,6 +44,9 @@ data ReqFailure =
   | AlterBlockActor
   | AlterBlockItem
   | AlterNothing
+  | CloseDistant
+  | CloseClosed
+  | CloseNothing
   | WaitUnskilled
   | YellUnskilled
   | MoveItemUnskilled
@@ -94,6 +97,9 @@ impossibleReqFailure reqFailure = case reqFailure of
   AlterBlockActor -> True  -- adjacent actor always visible
   AlterBlockItem -> True  -- adjacent item always visible
   AlterNothing -> True
+  CloseDistant -> False
+  CloseClosed -> False
+  CloseNothing -> False
   WaitUnskilled -> False  -- unidentified skill items
   YellUnskilled -> False  -- unidentified skill items
   MoveItemUnskilled -> False  -- unidentified skill items
@@ -141,6 +147,9 @@ showReqFailure reqFailure = case reqFailure of
   AlterBlockActor -> "blocked by an actor"
   AlterBlockItem -> "jammed by an item"
   AlterNothing -> "wasting time on altering nothing"
+  CloseDistant -> "trying to close a dinstant object"
+  CloseClosed -> "already closed"
+  CloseNothing -> "wasting time on closing nothing"
   WaitUnskilled -> "too low wait stat"
   YellUnskilled -> "actors unskilled in waiting cannot yell/yawn"
   MoveItemUnskilled -> "too low item moving stat"


### PR DESCRIPTION
#134, continuation of [this PR](https://github.com/LambdaHack/LambdaHack/pull/179).

I made couple assumptions:
* player character doesn't have to test his skill to close anything that's already open. It's disputable, e.g. I can imagine a door having a lock sophisticated enough to require certain skill or item to close them. 
* player character can close anything that he can reach, even if he can't see it;
* [here](https://github.com/rszczers/LambdaHack/blob/6fb84cb47e6c6d33255435f27a2321454f67961f/engine-src/Game/LambdaHack/Client/UI/HandleHumanGlobalM.hs#L944-L945) I've assumed that every open `TileKind` has `tname` beginning with word "open" (e.g. "open door", "open chest"). That's how i make messages like "you close north door".

My first thought was to make use of `alterTileAtPos`, but there's [some overhead](https://github.com/rszczers/LambdaHack/blob/6fb84cb47e6c6d33255435f27a2321454f67961f/engine-src/Game/LambdaHack/Client/UI/HandleHumanGlobalM.hs#L1032-L1055) in generic checking that player can alter a tile. I decided to rewrite it passing some of those tests that seemed unnecessary.

Well, it's a mess, but I hope this time it does what it should do :-D 