### PR TITLE
Fix in-game macro system

### DIFF
--- a/GameDefinition/game-src/Client/UI/Content/Input.hs
+++ b/GameDefinition/game-src/Client/UI/Content/Input.hs
@@ -181,6 +181,7 @@ standardKeysAndMouse = InputContentRaw $ map evalKeyDef $
   , ("F1", ([CmdMeta, CmdDashboard], "display help immediately", Help))
   , ("F12", ([CmdMeta], "open dashboard", Dashboard))
   , ("v", ([CmdMeta], "voice again the recorded commands", Repeat 1))
+  , ("A-v", ([CmdMeta], "repeat last action", RepeatLast))
   , ("V", repeatTriple 100)
   , ("C-v", addCmdCategory CmdNoHelp $ replaceDesc "" $ repeatTriple 1000)
   , ("C-V", addCmdCategory CmdNoHelp $ replaceDesc "" $ repeatTriple 25)

--- a/engine-src/Game/LambdaHack/Client/UI.hs
+++ b/engine-src/Game/LambdaHack/Client/UI.hs
@@ -23,6 +23,7 @@ import Prelude ()
 
 import Game.LambdaHack.Core.Prelude
 
+import qualified Data.Bifunctor as B
 import qualified Data.EnumMap.Strict as EM
 import qualified Data.EnumSet as ES
 import qualified Data.Map.Strict as M
@@ -175,7 +176,7 @@ humanCommand = do
                          then smacroBuffer sess
                          -- Exclude from in-game macros keystrokes that
                          -- start/stop recording a macro.
-                         else (km :) <$> smacroBuffer sess
+                         else (km :) `B.first` smacroBuffer sess
                      } 
               cmdHumanSem cmd
             _ -> let msgKey = "unknown command <" <> K.showKM km <> ">"

--- a/engine-src/Game/LambdaHack/Client/UI/FrameM.hs
+++ b/engine-src/Game/LambdaHack/Client/UI/FrameM.hs
@@ -102,14 +102,14 @@ promptGetKey dm ovs onBlank frontKeyKeys = do
   keyPressed <- anyKeyPressed
   report <- getsSession $ newReport . shistory
   let msgDisturbs = anyInReport disturbsResting report
-  lastPlayOld <- getsSession slastPlay
+  InGameMacro lastPlayOld <- getsSession slastPlay
   km <- case lastPlayOld of
     km : kms | not keyPressed
                && (null frontKeyKeys || km `elem` frontKeyKeys)
                && not msgDisturbs -> do
       frontKeyFrame <- drawOverlay dm onBlank ovs lidV
       displayFrames lidV [Just frontKeyFrame]
-      modifySession $ \sess -> sess {slastPlay = kms}
+      modifySession $ \sess -> sess {slastPlay = InGameMacro kms}
       msgAdd MsgMacro $ "Voicing '" <> tshow km <> "'."
       return km
     _ : _ -> do
@@ -145,8 +145,9 @@ stopPlayBack = msgAdd0 MsgStopPlayback "!"
 
 resetPlayBack :: MonadClientUI m => m ()
 resetPlayBack = do
-  lastPlayOld <- getsSession slastPlay
-  unless (null lastPlayOld) $ modifySession $ \sess -> sess {slastPlay = []}
+  InGameMacro lastPlayOld <- getsSession slastPlay
+  unless (null lastPlayOld) 
+    $ modifySession $ \sess -> sess {slastPlay = mempty}
   srunning <- getsSession srunning
   case srunning of
     Nothing -> return ()

--- a/engine-src/Game/LambdaHack/Client/UI/FrameM.hs
+++ b/engine-src/Game/LambdaHack/Client/UI/FrameM.hs
@@ -137,10 +137,7 @@ promptGetKey dm ovs onBlank frontKeyKeys = do
           resetPressedKeys
       recordHistory
       connFrontendFrontKey frontKeyKeys frontKeyFrame
-  LastRecord seqCurrent seqPrevious k <- getsSession slastRecord
-  let slastRecord = LastRecord (km : seqCurrent) seqPrevious k
-  modifySession $ \sess -> sess { slastRecord
-                                , sdisplayNeeded = False }
+  modifySession $ \sess -> sess { sdisplayNeeded = False }
   return km
 
 stopPlayBack :: MonadClientUI m => m ()
@@ -149,13 +146,7 @@ stopPlayBack = msgAdd0 MsgStopPlayback "!"
 resetPlayBack :: MonadClientUI m => m ()
 resetPlayBack = do
   lastPlayOld <- getsSession slastPlay
-  unless (null lastPlayOld) $ do
-    modifySession $ \sess -> sess {slastPlay = []}
-    LastRecord _ _ k <- getsSession slastRecord
-    when (k > 0) $ do
-      -- Needed to properly cancel macros that contain apostrophes.
-      modifySession $ \sess -> sess {slastRecord = LastRecord [] [] 0}
-      promptAdd0 "Macro recording aborted."
+  unless (null lastPlayOld) $ modifySession $ \sess -> sess {slastPlay = []}
   srunning <- getsSession srunning
   case srunning of
     Nothing -> return ()

--- a/engine-src/Game/LambdaHack/Client/UI/FrameM.hs
+++ b/engine-src/Game/LambdaHack/Client/UI/FrameM.hs
@@ -103,16 +103,16 @@ promptGetKey dm ovs onBlank frontKeyKeys = do
   report <- getsSession $ newReport . shistory
   let msgDisturbs = anyInReport disturbsResting report
   lastPlayOld <- getsSession slastPlay
-  km <- case unMacro lastPlayOld of
-    km : kms | not keyPressed
-               && (null frontKeyKeys || km `elem` frontKeyKeys)
-               && not msgDisturbs -> do
+  km <- case lastPlayOld of
+    KeyMacro (km : kms) | not keyPressed
+                          && (null frontKeyKeys || km `elem` frontKeyKeys)
+                          && not msgDisturbs -> do
       frontKeyFrame <- drawOverlay dm onBlank ovs lidV
       displayFrames lidV [Just frontKeyFrame]
       modifySession $ \sess -> sess {slastPlay = KeyMacro kms}
       msgAdd MsgMacro $ "Voicing '" <> tshow km <> "'."
       return km
-    _ : _ -> do
+    KeyMacro (_ : _) -> do
       -- We can't continue playback, so wipe out old slastPlay, srunning, etc.
       resetPlayBack
       resetPressedKeys
@@ -123,7 +123,7 @@ promptGetKey dm ovs onBlank frontKeyKeys = do
       frontKeyFrame <- drawOverlay dm onBlank ovs2 lidV
       recordHistory
       connFrontendFrontKey frontKeyKeys frontKeyFrame
-    [] -> do
+    KeyMacro [] -> do
       -- If we ask for a key, then we don't want to run any more
       -- and we want to avoid changing leader back to initial run leader
       -- at the nearest @stopPlayBack@, etc.

--- a/engine-src/Game/LambdaHack/Client/UI/HandleHumanGlobalM.hs
+++ b/engine-src/Game/LambdaHack/Client/UI/HandleHumanGlobalM.hs
@@ -308,7 +308,7 @@ moveRunHuman initialStep finalGoal run runAhead dir = do
       cli {srunning = Just runParams}
     when runAhead $
       modifySession $ \cli ->
-        cli {slastPlay = map K.mkKM macroRun25 ++ slastPlay cli}
+        cli {slastPlay = (InGameMacro . map K.mkKM $ macroRun25) <> slastPlay cli}
   -- When running, the invisible actor is hit (not displaced!),
   -- so that running in the presence of roving invisible
   -- actors is equivalent to moving (with visible actors

--- a/engine-src/Game/LambdaHack/Client/UI/HandleHumanGlobalM.hs
+++ b/engine-src/Game/LambdaHack/Client/UI/HandleHumanGlobalM.hs
@@ -308,7 +308,7 @@ moveRunHuman initialStep finalGoal run runAhead dir = do
       cli {srunning = Just runParams}
     when runAhead $
       modifySession $ \cli ->
-        cli {slastPlay = (InGameMacro . map K.mkKM $ macroRun25) <> slastPlay cli}
+        cli {slastPlay = (KeyMacro . map K.mkKM $ macroRun25) <> slastPlay cli}
   -- When running, the invisible actor is hit (not displaced!),
   -- so that running in the presence of roving invisible
   -- actors is equivalent to moving (with visible actors
@@ -947,7 +947,7 @@ alterDirHuman = pickPoint "modify" >>= \case
 alterTileAtPos :: MonadClientUI m
                => Point
                -> m (FailOrCmd RequestTimed)
-alterTileAtPos tpos = alterCommon False tpos
+alterTileAtPos = alterCommon False
 
 -- | Verify that the tile can be transformed or any embedded item effect
 -- triggered and the player is fine, if the effect is dangerous or grave,
@@ -992,7 +992,7 @@ processTileActions source tpos tas = do
           failWith "unable to modify at this time"
             -- related to, among others, @SfxNoItemsForTile@ on the server
       processTA (ta : rest) = case ta of
-        Tile.EmbedAction (iid, _) -> do
+        Tile.EmbedAction (iid, _) ->
           -- Embeds are activated in the order in tile definition
           -- and never after the tile is changed.
           -- We assume the item would trigger and we let the player

--- a/engine-src/Game/LambdaHack/Client/UI/HandleHumanLocalM.hs
+++ b/engine-src/Game/LambdaHack/Client/UI/HandleHumanLocalM.hs
@@ -682,7 +682,7 @@ selectWithPointerHuman = do
 repeatHuman :: MonadClientUI m => Int -> m ()
 repeatHuman n = do
   macro <- getsSession smacroBuffer
-  let nmacro k | k == 1 = reverse . unMacro . fromRight mempty $ macro
+  let nmacro k | k == 1 = unMacro . fromRight mempty $ macro
                -- Don't repeat macro while recording one.
                | otherwise = concat . replicate k $ nmacro 1
   modifySession $ \sess -> 
@@ -707,7 +707,8 @@ recordHuman = do
        modifySession $ \sess -> sess { smacroBuffer = Left [] }
        promptAdd0 "Recording a macro. Stop recording with the same key."
      Left xs -> do
-       modifySession $ \sess -> sess { smacroBuffer = Right . KeyMacro $ xs }
+       modifySession $ \sess -> 
+         sess { smacroBuffer = Right . KeyMacro . reverse $ xs }
        promptAdd0 "Macro recording stopped."
 
 -- * AllHistory

--- a/engine-src/Game/LambdaHack/Client/UI/HandleHumanM.hs
+++ b/engine-src/Game/LambdaHack/Client/UI/HandleHumanM.hs
@@ -124,6 +124,7 @@ cmdAction cmd = case cmd of
   SelectNone -> addNoError selectNoneHuman
   SelectWithPointer -> Left <$> selectWithPointerHuman
   Repeat n -> addNoError $ repeatHuman n
+  RepeatLast -> addNoError $ repeatLastHuman
   Record -> addNoError recordHuman
   AllHistory -> addNoError allHistoryHuman
   LastHistory -> addNoError lastHistoryHuman

--- a/engine-src/Game/LambdaHack/Client/UI/HumanCmd.hs
+++ b/engine-src/Game/LambdaHack/Client/UI/HumanCmd.hs
@@ -160,6 +160,7 @@ data HumanCmd =
   | SelectNone
   | SelectWithPointer
   | Repeat Int
+  | RepeatLast
   | Record
   | AllHistory
   | LastHistory

--- a/engine-src/Game/LambdaHack/Client/UI/SessionUI.hs
+++ b/engine-src/Game/LambdaHack/Client/UI/SessionUI.hs
@@ -55,7 +55,7 @@ data SessionUI = SessionUI
   , shistory       :: History       -- ^ history of messages
   , spointer       :: K.PointUI     -- ^ mouse pointer position
   , slastAction    :: Maybe K.KM    -- ^ last pressed key
-  , smacroBuffer   :: Either Macro [K.KM]
+  , smacroBuffer   :: Either [K.KM] Macro 
                                     -- ^ in-game recorded macro
   , slastPlay      :: Macro         -- ^ state of key sequence playback
   , slastLost      :: ES.EnumSet ActorId
@@ -86,8 +86,11 @@ type ItemDictUI = EM.EnumMap ItemId LevelId
 newtype AimMode = AimMode { aimLevelId :: LevelId }
   deriving (Show, Eq, Binary)
 
--- | Recorded in-game macro.
-newtype Macro = InGameMacro { unMacro :: [K.KM] }
+-- | In-game macros. We record only the keystrokes that are bound to commands,
+-- with one exception -- we exclude keys that invoke Record command.
+-- Keys are kept in reverse order, i.e. the first element of the list is
+-- replayed as the last.
+newtype Macro = KeyMacro { unMacro :: [K.KM] }
   deriving (Eq, Binary, Semigroup, Monoid)
 
 -- | Parameters of the current run.
@@ -128,7 +131,7 @@ emptySessionUI sUIOptions =
     , shistory = emptyHistory 0
     , spointer = K.PointUI 0 0
     , slastAction = Nothing
-    , smacroBuffer = Left mempty
+    , smacroBuffer = Right mempty
     , slastPlay = mempty
     , slastLost = ES.empty
     , swaitTimes = 0
@@ -194,7 +197,7 @@ instance Binary SessionUI where
         sxhairMoused = True
         spointer = K.PointUI 0 0
         slastAction = Nothing
-        smacroBuffer = Left mempty
+        smacroBuffer = Right mempty
         slastPlay = mempty
         slastLost = ES.empty
         swaitTimes = 0

--- a/engine-src/Game/LambdaHack/Client/UI/SessionUI.hs
+++ b/engine-src/Game/LambdaHack/Client/UI/SessionUI.hs
@@ -55,8 +55,8 @@ data SessionUI = SessionUI
   , shistory       :: History       -- ^ history of messages
   , spointer       :: K.PointUI     -- ^ mouse pointer position
   , slastAction    :: Maybe K.KM    -- ^ last pressed key
-  , smacroBuffer   :: [K.KM]        -- ^ in-game recorded macro
-  , srecording     :: Bool          -- ^ recording status
+  , smacroBuffer   :: Either [K.KM] [K.KM]
+                                    -- ^ in-game recorded macro
   , slastPlay      :: [K.KM]        -- ^ state of key sequence playback
   , slastLost      :: ES.EnumSet ActorId
                                     -- ^ actors that just got out of sight
@@ -124,8 +124,7 @@ emptySessionUI sUIOptions =
     , shistory = emptyHistory 0
     , spointer = K.PointUI 0 0
     , slastAction = Nothing
-    , smacroBuffer = []
-    , srecording = False
+    , smacroBuffer = Left []
     , slastPlay = []
     , slastLost = ES.empty
     , swaitTimes = 0
@@ -191,9 +190,8 @@ instance Binary SessionUI where
         sxhairMoused = True
         spointer = K.PointUI 0 0
         slastAction = Nothing
-        smacroBuffer = []
+        smacroBuffer = Left []
         slastPlay = []
-        srecording = False
         slastLost = ES.empty
         swaitTimes = 0
         swasAutomated = False

--- a/engine-src/Game/LambdaHack/Client/UI/SessionUI.hs
+++ b/engine-src/Game/LambdaHack/Client/UI/SessionUI.hs
@@ -55,8 +55,9 @@ data SessionUI = SessionUI
   , shistory       :: History       -- ^ history of messages
   , spointer       :: K.PointUI     -- ^ mouse pointer position
   , slastAction    :: Maybe K.KM    -- ^ last pressed key
-  , smacroBuffer   :: Either [K.KM] Macro 
-                                    -- ^ in-game recorded macro
+  , smacroBuffer   :: Either [K.KM] Macro
+                                    -- ^ state of recording a macro; if Left,
+                                    --   record keystrokes
   , slastPlay      :: Macro         -- ^ state of key sequence playback
   , slastLost      :: ES.EnumSet ActorId
                                     -- ^ actors that just got out of sight
@@ -88,8 +89,8 @@ newtype AimMode = AimMode { aimLevelId :: LevelId }
 
 -- | In-game macros. We record only the keystrokes that are bound to commands,
 -- with one exception -- we exclude keys that invoke Record command.
--- Keys are kept in reverse order, i.e. the first element of the list is
--- replayed as the last.
+-- Keys are kept in the same order in which they're meant to be replayed,
+-- i.e. the first element of the list is replayed also as the first one.
 newtype Macro = KeyMacro { unMacro :: [K.KM] }
   deriving (Eq, Binary, Semigroup, Monoid)
 

--- a/engine-src/Game/LambdaHack/Client/UI/SessionUI.hs
+++ b/engine-src/Game/LambdaHack/Client/UI/SessionUI.hs
@@ -2,7 +2,7 @@
 -- | The client UI session state.
 module Game.LambdaHack.Client.UI.SessionUI
   ( SessionUI(..), ItemDictUI, AimMode(..), RunParams(..)
-  , HintMode(..)
+  , HintMode(..), Macro(..)
   , emptySessionUI, toggleMarkVision, toggleMarkSmell, getActorUI
   ) where
 
@@ -55,9 +55,9 @@ data SessionUI = SessionUI
   , shistory       :: History       -- ^ history of messages
   , spointer       :: K.PointUI     -- ^ mouse pointer position
   , slastAction    :: Maybe K.KM    -- ^ last pressed key
-  , smacroBuffer   :: Either [K.KM] [K.KM]
+  , smacroBuffer   :: Either Macro [K.KM]
                                     -- ^ in-game recorded macro
-  , slastPlay      :: [K.KM]        -- ^ state of key sequence playback
+  , slastPlay      :: Macro         -- ^ state of key sequence playback
   , slastLost      :: ES.EnumSet ActorId
                                     -- ^ actors that just got out of sight
   , swaitTimes     :: Int           -- ^ player just waited this many times
@@ -85,6 +85,10 @@ type ItemDictUI = EM.EnumMap ItemId LevelId
 -- | Current aiming mode of a client.
 newtype AimMode = AimMode { aimLevelId :: LevelId }
   deriving (Show, Eq, Binary)
+
+-- | Recorded in-game macro.
+newtype Macro = InGameMacro { unMacro :: [K.KM] }
+  deriving (Eq, Binary, Semigroup, Monoid)
 
 -- | Parameters of the current run.
 data RunParams = RunParams
@@ -124,8 +128,8 @@ emptySessionUI sUIOptions =
     , shistory = emptyHistory 0
     , spointer = K.PointUI 0 0
     , slastAction = Nothing
-    , smacroBuffer = Left []
-    , slastPlay = []
+    , smacroBuffer = Left mempty
+    , slastPlay = mempty
     , slastLost = ES.empty
     , swaitTimes = 0
     , swasAutomated = False
@@ -190,8 +194,8 @@ instance Binary SessionUI where
         sxhairMoused = True
         spointer = K.PointUI 0 0
         slastAction = Nothing
-        smacroBuffer = Left []
-        slastPlay = []
+        smacroBuffer = Left mempty
+        slastPlay = mempty
         slastLost = ES.empty
         swaitTimes = 0
         swasAutomated = False


### PR DESCRIPTION
In relation to discussion we had in #161. I allowed myself to simplify previous solution.

Macro system is modified in such a way, that both last user's action and his macro gets recorded in separate buffers as one or sequence of keystrokes, accordingly. We allow user to record self-referencing macros for fun and profit (infinite Benny Hill running scenarios, yay!). Since all macros can be easily interrupted (well, it's _works-for-me_ solution), we don't constrain macro length. Consider this: if only in-game creatures had stamina, we could hopefully run them to death! IMO it's a valid survival strategy :-D

Player's last action gets replayed now by separate command (`RepeatLast`, binded to `alt+v`). In previous version last user's action and recorded macro shared the same buffer and were overwriting each other.