### PR TITLE
Record nested macros on stack

### DIFF
--- a/engine-src/Game/LambdaHack/Client/UI.hs
+++ b/engine-src/Game/LambdaHack/Client/UI.hs
@@ -177,6 +177,11 @@ humanCommand = do
                  in weaveJust <$> failWith (T.pack msgKey)
         -- The command was failed or successful and if the latter,
         -- possibly took some time.
+        KeyMacro kms <- getsSession slastPlay
+        when (null kms) $ modifySession $ \sess ->
+          sess { smacroStack = [last $ smacroStack sess] }
+          -- GC all macro buffers, except in-game macro buffer, if there's
+          -- nothing left to do.
         case abortOrCmd of
           Right cmdS ->
             -- Exit the loop and let other actors act. No next key needed

--- a/engine-src/Game/LambdaHack/Client/UI/SessionUI.hs
+++ b/engine-src/Game/LambdaHack/Client/UI/SessionUI.hs
@@ -55,9 +55,11 @@ data SessionUI = SessionUI
   , shistory       :: History       -- ^ history of messages
   , spointer       :: K.PointUI     -- ^ mouse pointer position
   , slastAction    :: Maybe K.KM    -- ^ last pressed key
-  , smacroBuffer   :: Either [K.KM] KeyMacro
-                                    -- ^ state of recording a macro; if Left,
-                                    --   record keystrokes
+  , smacroStack    :: [Either [K.KM] KeyMacro]
+                                    -- ^ non-empty stack of macro buffers that
+                                    --   contains at least in-game macro buffer;
+                                    --   record keystrokes in the first Left
+                                    --   buffer
   , slastPlay      :: KeyMacro      -- ^ state of key sequence playback
   , slastLost      :: ES.EnumSet ActorId
                                     -- ^ actors that just got out of sight
@@ -133,7 +135,7 @@ emptySessionUI sUIOptions =
     , shistory = emptyHistory 0
     , spointer = K.PointUI 0 0
     , slastAction = Nothing
-    , smacroBuffer = Right mempty
+    , smacroStack = [Right mempty]
     , slastPlay = mempty
     , slastLost = ES.empty
     , swaitTimes = 0
@@ -199,7 +201,7 @@ instance Binary SessionUI where
         sxhairMoused = True
         spointer = K.PointUI 0 0
         slastAction = Nothing
-        smacroBuffer = Right mempty
+        smacroStack = [Right mempty]
         slastPlay = mempty
         slastLost = ES.empty
         swaitTimes = 0


### PR DESCRIPTION
In relation to #189.

All the macros are placed in a stack of Either macro buffers, since macros can be nested. Bottom of stack is reserved for the user's in-game macro buffer, so the stack is never empty.

We record keystrokes in the topmost Left macro buffer. At any time there's at most one Right macro buffer, i.e. a buffer that's not available to record to, but ready to be repeated from the macro bellow
it.

We push new buffer to the stack whenever macro is recording a macro itself.

This feature deserves doing automatic tests. Here's a demo for two test cases:

1. Let `j` be an atomic action, `M` an in-game buffer, `a` := `[', j, ', ', j, ']`.

   Repeating macro `a`:
   
   | # | smacroStack          | slastPlay  |
   | - | -------------------- | ------------ |
   | 1 | `[Right [], M]`      | `'j''j'`
   | 2 | `[Left [], M]`       | `j''j'`
   | 3 | `[Left ["j"], M]`    | `''j'`
   | 4 | `[Right ["j"], M]`   | `'j'`
   | 5 | `[Left [], M]`       | `j'`
   | 6 | `[Left ["j"], M]`    | `'`
   | 7 | `[Right ["j"], M]`   |
   
2. Let `j` be an atomic action, `M` an in-game buffer, `A-a` := `[',A-b,']`, `A-b` := `[',j,']`. 
   
   Repeating macro `A-a`:
   
   | # | smacroStack                           | slastPlay  |
   | - | ------------------------------------- | ------------ |
   | 1 | `[Right [], M]                  `     | `'A-b'`
   | 2 | `[Left [], M]                   `     | `A-b'`
   | 3 | `[Right [], Left ["A-b"], M]    `     | `'j''`
   | 4 | `[Left [], Left ["A-b"], M]     `     | `j''`
   | 5 | `[Left ["j"], Left ["A-b"], M]  `     | `''`
   | 6 | `[Right ["j"], Left ["A-b"], M] `     | `'`
   | 7 | `[Right ["A-b"], M]             `     |

Right after there's nothing left on `slastPlay`, we GC all what's left on `smacroStack` leaving only `M`.