### PR TITLE
Fix nested macros (once and for all)

### DIFF
--- a/engine-src/Game/LambdaHack/Client/UI.hs
+++ b/engine-src/Game/LambdaHack/Client/UI.hs
@@ -168,8 +168,8 @@ humanCommand = do
                          else 0
                      , sactionPending = case cmd of
                          (HumanCmd.RepeatLast _) -> sactionPending sess
-                         -- We can repeat every last action except 'repeat last
-                         -- action' action, so here we ommit that one.
+                         -- Don't save repeating last action key as the last
+                         -- key handled.
                          _ ->
                            let oldBuffer = head (sactionPending sess)
                                newBuffer = oldBuffer { slastAction = Just km }

--- a/engine-src/Game/LambdaHack/Client/UI/HandleHumanGlobalM.hs
+++ b/engine-src/Game/LambdaHack/Client/UI/HandleHumanGlobalM.hs
@@ -308,7 +308,10 @@ moveRunHuman initialStep finalGoal run runAhead dir = do
       cli {srunning = Just runParams}
     when runAhead $
       modifySession $ \cli ->
-        cli {slastPlay = (KeyMacro . map K.mkKM $ macroRun25) <> slastPlay cli}
+        let oldBuffer = head $ sactionPending cli
+            newBuffer = oldBuffer {slastPlay =
+              (KeyMacro . map K.mkKM $ macroRun25) <> slastPlay oldBuffer}
+         in cli {sactionPending = newBuffer : tail (sactionPending cli) }
   -- When running, the invisible actor is hit (not displaced!),
   -- so that running in the presence of roving invisible
   -- actors is equivalent to moving (with visible actors

--- a/engine-src/Game/LambdaHack/Client/UI/HandleHumanLocalM.hs
+++ b/engine-src/Game/LambdaHack/Client/UI/HandleHumanLocalM.hs
@@ -742,7 +742,7 @@ recordHuman = do
 recordHumanTransition :: [ActionBuffer] -> ([ActionBuffer], Text)
 recordHumanTransition [] = error "no macro buffer to record to"
 recordHumanTransition (abuff : abuffs) =
-  let (buffer, msg)= case smacroBuffer abuff of
+  let (buffer, msg) = case smacroBuffer abuff of
         Right _ ->
           -- Start recording in-game macro.
           (Left [], "Recording a macro. Stop recording with the same key.")

--- a/test/test.hs
+++ b/test/test.hs
@@ -1,6 +1,7 @@
 import Prelude ()
 
 import qualified Data.Map.Strict as M
+import           Data.Bifunctor                 ( bimap )
 import           Options.Applicative
 import           Test.Tasty
 import           Test.Tasty.HUnit
@@ -32,127 +33,142 @@ macroTests = testGroup "macroTests" $
       listToKeyMacro = KeyMacro . map K.mkKM
       bindInput l input =
         let ltriple = M.fromList $ map (\(k, ks) ->
-             (K.mkKM k, ([], "", HumanCmd.Macro $ map (: []) ks))) l
+              (K.mkKM k, ([], "", HumanCmd.Macro $ map (: []) ks))) l
         in input {IC.bcmdMap = M.union ltriple $ IC.bcmdMap input}
-  in [ testCase "Macro 1 from PR#192 description" $ do
-         map fst (unwindMacros coinput (stringToKeyMacro "'j''j'"))
-         @?= [ ([Right []],       "'j''j'")
-             , ([Left []],        "j''j'")
-             , ([Left ["j"]],     "''j'")
-             , ([Right ["j"]],    "'j'")
-             , ([Left []],        "j'")
-             , ([Left ["j"]],     "'")
-             , ([Right ["j"]],    "") ]
-     , testCase "Macro 1 from Issue#189 description" $ do
-         snd (last (unwindMacros (bindInput [ ("a", "'bc'v")
-                                            , ("c", "'aaa'v") ] coinput)
-                                 (stringToKeyMacro "a")))
-         @?= "macro looped"
-     , testCase "Macro 2 from Issue#189 description" $ do
+  in [ testCase "Macro 1 from PR#192 description" $
+         fst <$> unwindMacros coinput (stringToKeyMacro "'j''j'")
+         @?= [ [ (Right "",     "'j''j'",  "")  ]
+             , [ (Left  "",     "j''j'",   "'") ]
+             , [ (Left  "j",    "''j'",    "j") ]
+             , [ (Right "j",    "'j'",     "'") ]
+             , [ (Left  "",     "j'",      "'") ]
+             , [ (Left  "j",    "'",       "j") ]
+             , [ (Right "j",    "",        "'") ]
+             ]
+     , testCase "Macro 1 from Issue#189 description" $
+         last (unwindMacros (bindInput [ ("a", "'bc'v")
+                                       , ("c", "'aaa'v") ] coinput)
+                 (stringToKeyMacro "a"))
+         @?= macroLooped
+     , testCase "Macro 2 from Issue#189 description" $
          snd (last (unwindMacros (bindInput [("a", "'x'")] coinput)
                                  (stringToKeyMacro "'a'")))
          @?= "x"
-     , testCase "Macro 3 from Issue#189 description" $ do
+     , testCase "Macro 3 from Issue#189 description" $
          snd (last (unwindMacros coinput (stringToKeyMacro "'x''x'")))
          @?= "xx"
-     , testCase "Macro 4 from Issue#189 description" $ do
+     , testCase "Macro 4 from Issue#189 description" $
          snd (last (unwindMacros coinput (stringToKeyMacro "'x''x'v")))
          @?= "xxx"
-     , testCase "Macro 5 from Issue#189 description" $ do
+     , testCase "Macro 5 from Issue#189 description" $
          snd (last (unwindMacros coinput (stringToKeyMacro "x'x'v")))
          @?= "xxx"
-     , testCase "Macro test 10" $ do
+     , testCase "Macro test 10" $
          snd (last (unwindMacros coinput (stringToKeyMacro "x'y'v")))
          @?= "xyy"
-     , testCase "Macro test 11" $ do
+     , testCase "Macro test 11" $
          snd (last (unwindMacros coinput (stringToKeyMacro "'x''y'v")))
          @?= "xyy"
-     , testCase "Macro test 12" $ do
+     , testCase "Macro test 12" $
          snd (last (unwindMacros coinput
                                  (listToKeyMacro ["x", "C-V"])))
          @?= "x"
-     , testCase "Macro test 13" $ do
+     , testCase "Macro test 13" $
          snd (last (unwindMacros coinput
                                  (listToKeyMacro ["'", "x", "'", "C-V"])))
          @?= "xxxxxxxxxxxxxxxxxxxxxxxxxx"
-     , testCase "Macro test 14" $ do
+     , testCase "Macro test 14" $
          snd (last (unwindMacros coinput
                                  (listToKeyMacro ["'", "x", "'", "y", "C-V"])))
          @?= "xyxxxxxxxxxxxxxxxxxxxxxxxxx"
-     -- , testCase "Macro test 15" $ do
-     --     snd (last (unwindMacros (bindInput [("a", "x")] coinput)
-     --                             (stringToKeyMacro "'a'v")))
-     --     @?= "xx"
-     , testCase "Macro test 16" $ do
+     , testCase "Macro test 15" $
+         snd (last (unwindMacros (bindInput [("a", "x")] coinput)
+                                 (stringToKeyMacro "'a'v")))
+         @?= "xx"
+     , testCase "Macro test 16" $
          snd (last (unwindMacros (bindInput [("a", "'x'")] coinput)
                                  (stringToKeyMacro "'a'v")))
          @?= "xx"
-     , testCase "Macro test 17" $ do
+     , testCase "Macro test 17" $
          snd (last (unwindMacros (bindInput [("a", "'x'v")] coinput)
                                  (stringToKeyMacro "a")))
          @?= "xx"
-     , testCase "Macro test 18" $ do
+     , testCase "Macro test 18" $
          snd (last (unwindMacros (bindInput [("a", "'x'v")] coinput)
                                  (stringToKeyMacro "'a'")))
          @?= "xx"
-     -- , testCase "Macro test 19" $ do
-     --     snd (last (unwindMacros (bindInput [("a", "'x'v")] coinput)
-     --                             (stringToKeyMacro "'a'v")))
-     --     @?= "xxxx"
-     -- , testCase "Macro test 20" $ do
-     --     snd (last (unwindMacros (bindInput [ ("a", "'bz'v")
-     --                                        , ("c", "'aaa'v") ] coinput)
-     --                             (stringToKeyMacro "c")))
-     --     @?= "bzbzbzbzbzbzbzbzbzbzbzbz"
+     , testCase "Macro test 19" $
+         snd (last (unwindMacros (bindInput [("a", "'x'v")] coinput)
+                                 (stringToKeyMacro "'a'v")))
+         @?= "xxxx"
+     , testCase "Macro test 20" $
+         snd (last (unwindMacros (bindInput [ ("a", "'bz'v")
+                                            , ("c", "'aaa'v") ] coinput)
+                                 (stringToKeyMacro "c")))
+         @?= "bzbzbzbzbzbzbzbzbzbzbzbz"
      ]
 
+type BufferTrace = [(Either String String, String, String)]
+type ActionLog = String
+
+macroLooped :: (BufferTrace, String)
+macroLooped = ([(Left mempty, [], [])], "macro looped")
+
 -- The mock for macro testing.
-unwindMacros :: IC.InputContent -> KeyMacro
-             -> [(([Either [String] [String]], String), String)]
-unwindMacros IC.InputContent{bcmdMap, brevMap} lastPlay0 =
-  let transitionMacros (0 :: Int) _ _ _ =
-        [(([], "macro looped"), "macro looped")]  -- probably
-      transitionMacros k macros lastPlay cmds =
-        storeTrace macros lastPlay cmds
-        : case lastPlay of
-          KeyMacro [] -> []
-          KeyMacro (km : rest) ->
-            let ((macros1, lastPlay1), cmds1) = case M.lookup km bcmdMap of
-                  Just (_, _, HumanCmd.Record) ->
-                    ((fst $ recordHumanTransition macros, KeyMacro rest), cmds)
-                  Just (_, _, HumanCmd.Macro ys) ->
-                    ( macroHumanTransition ys brevMap macros (KeyMacro rest)
-                    , cmds )
-                  Just (_, _, HumanCmd.Repeat n) ->
-                    ( (macros, repeatHumanTransition n macros (KeyMacro rest))
-                    , cmds )
-                  _ -> ((macros, KeyMacro rest), cmds ++ [km])
-                macros2 = addToMacro brevMap km macros1
-            in transitionMacros (k - 1) macros2 lastPlay1 cmds1
-      storeTrace macros lastPlay cmds =
-        let tmacros = map (either (Left . map K.showKM)
-                                  (Right . map K.showKM . unKeyMacro))
-                          macros
-            tlastPlay = concatMap K.showKM $ unKeyMacro lastPlay
-            tcmds = concatMap K.showKM cmds
-        in ((tmacros, tlastPlay), tcmds)
-  in transitionMacros 1000 [Right (KeyMacro [])] lastPlay0 []
+unwindMacros :: IC.InputContent -> KeyMacro -> [(BufferTrace, ActionLog)]
+unwindMacros IC.InputContent{bcmdMap, brevMap} startMacro =
+  let transitionMacros :: Int -> [K.KM] -> [ActionBuffer]
+                       -> [(BufferTrace, ActionLog)]
+      transitionMacros (0 :: Int) _ _ = [macroLooped]  -- probably
+      transitionMacros _ _ [] = error "bad initial conditions"
+      transitionMacros k out abuffs@(abuff : _) =
+        storeTrace abuffs out : case slastPlay abuff of
+        KeyMacro [] -> []
+        KeyMacro (km : kms) ->
+          let abuffs0 = addToMacro brevMap km abuffs
 
-{-
+              abuffs1 = case M.lookup km bcmdMap of
+                Just (_, _, HumanCmd.RepeatLast _) -> abuffs0
+                _ -> let oldBuffer = head abuffs0
+                         newBuffer = oldBuffer { slastAction = Just km }
+                      in newBuffer : tail abuffs0
 
-2. Let `j` be an atomic action and the starting content of `slastPlay` be `[',A-b,']` and `A-b` := `[',j,']`.
+              abuffs2 =
+                let abuff1 = head abuffs1
+                in abuff1 { slastPlay = KeyMacro kms } : tail abuffs1
 
-   | # | smacroStack                           | slastPlay  |
-   | - | ------------------------------------- | ------------ |
-   | 1 | `[Right []]                  `     | `'A-b'`
-   | 2 | `[Left []]                   `     | `A-b'`
-   | 3 | `[Right [], Left ["A-b"]]    `     | `'j''`
-   | 4 | `[Left [], Left ["A-b"]]     `     | `j''`
-   | 5 | `[Left ["j"], Left ["A-b"]]  `     | `''`
-   | 6 | `[Right ["j"], Left ["A-b"]] `     | `'`
-   | 7 | `[Right ["A-b"]]             `     |
+              (abuffs3, out') = case M.lookup km bcmdMap of
+                Just (_, _, HumanCmd.Record) ->
+                  (fst $ recordHumanTransition abuffs2, out)
+                Just (_, _, HumanCmd.Macro ys) ->
+                  (macroHumanTransition ys abuffs2, out)
+                Just (_, _, HumanCmd.Repeat n) ->
+                  (repeatHumanTransition n abuffs2, out)
+                Just (_, _, HumanCmd.RepeatLast n) ->
+                  (repeatLastHumanTransition n abuffs2, out)
+                _ -> (abuffs2, out ++ [km])
 
--}
+              abuffs4 = case abuffs3 of
+                ActionBuffer _ (KeyMacro acts) _ : as
+                  | not (null as) && null acts -> as
+                _ -> abuffs3
+
+          in transitionMacros (k - 1) out' abuffs4
+
+      storeTrace :: [ActionBuffer] -> [K.KM] -> (BufferTrace, ActionLog)
+      storeTrace abuffs out =
+        let tmacros = bimap (concatMap K.showKM) (concatMap K.showKM . unKeyMacro)
+                    . smacroBuffer <$> abuffs
+            tlastPlay = concatMap K.showKM . unKeyMacro . slastPlay <$> abuffs
+            tlastAction = maybe "" K.showKM . slastAction <$> abuffs
+            toutput = concatMap K.showKM out
+        in (zip3 tmacros tlastPlay tlastAction, toutput)
+
+      emptyBuffer = ActionBuffer { smacroBuffer = Right mempty
+                                 , slastPlay = mempty
+                                 , slastAction = Nothing }
+
+  in transitionMacros 1000 [] [emptyBuffer { slastPlay = startMacro }]
 
 integrationTests :: TestTree
 integrationTests = testGroup "integrationTests"


### PR DESCRIPTION
Implemented the idea from #161 and tweaked up mocks.

We handle each predefined macro locally. Whenever handling a macro, we push onto the stack a new buffer containing all actions introduced by the macro, and separate places for in-game macros recorded by the macro and last action performed in the macro.

Since macros can be made of other predefined macros, we stack buffers on top of each other. Buffers are being consumed from the top until there's only the last one left, i.e. the user's buffer dedicated for handling in-game macros. We pop a buffer when there's no actions pending to handle in it.