### PR TITLE
Simplified mission descriptions

### DIFF
--- a/GameDefinition/Content/ModeKind.hs
+++ b/GameDefinition/Content/ModeKind.hs
@@ -99,7 +99,8 @@ raid = ModeKind
       , "* Find exit and escape ASAP"
       ]
   , mdesc   = "An incredibly advanced typing machine worth 100 gold is buried at the exit of this maze. Be the first to find it and fund a research team that makes typing accurate and dependable forever."
-  , mnote   = "In addition to initiating the (loose) game plot, this scenario serves as an introductory tutorial. There is only one level. Relax, explore, gather loot, find the exit and escape. With some luck, you won't even need to fight anything or use any items. Feel free to scout with only one of the heroes and keep the other one immobile, e.g., standing guard over the squad's shared inventory stash. If in grave danger, retreat with the scout to join forces with the guard. The more gold collected and the faster the victory, the higher the score."
+  , mmotivation = "In addition to initiating the (loose) game plot, this scenario serves as an introductory tutorial. There is only one level. Relax, explore, gather loot, find the exit and escape. With some luck, you won't even need to fight anything or use any items."
+  , mhint= "Feel free to scout with only one of the heroes and keep the other one immobile, e.g., standing guard over the squad's shared inventory stash. If in grave danger, retreat with the scout to join forces with the guard. The more gold collected and the faster the victory, the higher the score."
   }
 
 brawl = ModeKind  -- sparse melee in daylight, with shade for melee ambush
@@ -117,7 +118,8 @@ brawl = ModeKind  -- sparse melee in daylight, with shade for melee ambush
       , "* Incapacitate all enemies ASAP"
       ]
   , mdesc   = "Your research team disagrees over a drink with some gentlemen scientists about premises of a relative completeness theorem and there's only one way to settle that. Remember to keep your party together when opponents are spotted, or they might be tempted to silence solitary disputants one by one and so win the altercation."
-  , mnote   = "In addition to advancing the game plot, this scenario trains melee, squad formation and stealth. If you get beaten, ponder the hints from the defeat message. The battle is completely symmetric, both in numbers, goals and squad capabilities (e.g., only the pointman moves, while all others either melee or wait). Observe and mimic the enemies and savour the fairness --- you won't find any in the main crawl scenario that follows."
+  , mmotivation = "In addition to advancing the game plot, this scenario trains melee, squad formation and stealth. If you get beaten, ponder the hints from the defeat message."
+  , mhint= "The battle is completely symmetric, both in numbers, goals and squad capabilities (e.g., only the pointman moves, while all others either melee or wait). Observe and mimic the enemies and savour the fairness --- you won't find any in the main crawl scenario that follows."
   }
 
 crawl = ModeKind
@@ -129,13 +131,14 @@ crawl = ModeKind
   , mendMsg = [ (Killed, "To think that followers of science and agents of enlightenment would earn death as their reward! Where did we err in our ways? Perhaps nature should not have been disturbed so brashly and the fell beasts woken up from their slumber so eagerly? Perhaps the gathered items should have been used for scientific experiments on the spot rather than hoarded as if of base covetousness? Or perhaps the challenge, chosen freely but without the foreknowledge of the grisly difficulty, was insurmountable and forlorn from the start, despite the enormous power of educated reason at out disposal?")
               , (Escape, "It's better to live to tell the tale than to choke on more than one can swallow. There was no more exquisite cultural artifacts and glorious scientific wonders in these forbidding tunnels anyway. Or were there?") ]
   , mrules  = T.unlines $
-      [ "* many levels"
+      [ "* Many levels"
       , "* Three heroes vs. spawned enemies"
       , "* Gather gold, gems and elixirs"
       , "* Find exit and escape ASAP"
       ]
   , mdesc   = "Enjoy the peaceful seclusion of these cold austere tunnels, but don't let wanton curiosity, greed and the ever-creeping abstraction madness keep you down there for too long. If you find survivors (whole or perturbed or segmented) of the past scientific missions, exercise extreme caution and engage or ignore at your discretion."
-  , mnote   = "This is the main, longest and most replayable scenario of the game. If you keep dying, attempt the next game modes as a breather (perhaps at lowered difficulty). They fill the gaps in the plot and teach particular skills that may come in handy and help you discover new tactics of your own or come up with a strategy for staving off the attrition."
+  , mmotivation = "This is the main, longest and most replayable scenario of the game."
+  , mhint= "If you keep dying, attempt the next game modes as a breather (perhaps at lowered difficulty). They fill the gaps in the plot and teach particular skills that may come in handy and help you discover new tactics of your own or come up with a strategy for staving off the attrition."
   }
 
 -- The trajectory tip is important because of tactics of scout looking from
@@ -160,7 +163,8 @@ shootout = ModeKind  -- sparse ranged in daylight
       , "* Incapacitate all enemies ASAP"
       ]
   , mdesc   = "Whose arguments are most striking and whose ideas fly fastest? Let's scatter up, attack the problems from different angles and find out."
-  , mnote   = "This scenario is a flashback, picking the plot up where brawl (2) left it. It also teaches specifically the ranged combat skill in the simplified setup of fully symmetric battle. Try to come up with the best squad formation for this tactical challenge. Don't despair if you run out of ammo, because if you aim truly, enemy has few hit points left at this point. In turn, when trying to avoid enemy projectiles, you can display the trajectory of any soaring entity by pointing it with the crosshair in aiming mode."
+  , mmotivation = "This scenario is a flashback, picking the plot up where brawl (2) left it. It also teaches specifically the ranged combat skill in the simplified setup of fully symmetric battle."
+  , mhint= "Try to come up with the best squad formation for this tactical challenge. Don't despair if you run out of ammo, because if you aim truly, enemy has few hit points left at this point. In turn, when trying to avoid enemy projectiles, you can display the trajectory of any soaring entity by pointing it with the crosshair in aiming mode."
   }
 
 hunt = ModeKind  -- melee vs ranged with reaction fire in daylight
@@ -177,7 +181,8 @@ hunt = ModeKind  -- melee vs ranged with reaction fire in daylight
       , "* Incapacitate all enemies ASAP"
       ]
   , mdesc   = "Who is the hunter and who is the prey?"
-  , mnote   = "This is yet another reminiscence of the events that led to the long crawl adventure. This episode is quite a tactical challenge, because enemies are allowed to fling their ammo simultaneously at you team, which has no such capacities and focuses on melee combat instead. Act accordingly."
+  , mmotivation = "This is yet another reminiscence of the events that led to the long crawl adventure. This episode is quite a tactical challenge, because enemies are allowed to fling their ammo simultaneously at your team, which has no such capacities and focuses on melee combat instead. Act accordingly."
+  , mhint= ""
   }
 
 escape = ModeKind  -- asymmetric ranged and stealth race at night
@@ -195,7 +200,8 @@ escape = ModeKind  -- asymmetric ranged and stealth race at night
       , "* Find exit and escape ASAP"
       ]
   , mdesc   = "Dwelling into dark matters is dangerous, so avoid the crowd of firebrand disputants, catch any gems of thought, find a way out and bring back a larger team to shed new light on the field."
-  , mnote   = ""
+  , mmotivation = ""
+  , mhint= ""
   }
 
 zoo = ModeKind  -- asymmetric crowd melee at night
@@ -212,7 +218,8 @@ zoo = ModeKind  -- asymmetric crowd melee at night
       , "* Incapacitate all enemies ASAP"
       ]
   , mdesc   = "The heat of the dispute reaches the nearby Wonders of Science and Nature exhibition, igniting greenery, nets and cages. Crazed animals must be dissuaded from ruining precious scientific equipment and setting back the otherwise fruitful exchange of ideas."
-  , mnote   = ""
+  , mmotivation = ""
+  , mhint= ""
   }
 
 -- The tactic is to sneak in the dark, highlight enemy with thrown torches
@@ -237,7 +244,8 @@ ambush = ModeKind  -- dense ranged with reaction fire vs melee at night
       , "* Assert control of the situation ASAP"
       ]
   , mdesc   = "Prevent hijacking of your ideas at all cost! Be stealthy, be observant, be aggressive. Fast execution is what makes or breaks a creative team."
-  , mnote   = ""
+  , mmotivation = ""
+  , mhint= ""
   }
 
 safari = ModeKind  -- Easter egg available only via screensaver
@@ -254,7 +262,8 @@ safari = ModeKind  -- Easter egg available only via screensaver
       , "* Find exit and escape ASAP"
       ]
   , mdesc   = "\"In this enactment you'll discover the joys of hunting the most exquisite of Earth's flora and fauna, both animal and semi-intelligent. Exit at the bottommost level.\" This is a drama script recovered from a monster nest debris."
-  , mnote   = ""
+  , mmotivation = ""
+  , mhint= ""
   }
 
 -- * Testing modes
@@ -268,7 +277,8 @@ dig = ModeKind
   , mendMsg = []
   , mrules  = ""
   , mdesc   = "Delve deeper!"
-  , mnote   = ""
+  , mmotivation = ""
+  , mhint= ""
   }
 
 see = ModeKind
@@ -280,7 +290,8 @@ see = ModeKind
   , mendMsg = []
   , mrules  = ""
   , mdesc   = "See all!"
-  , mnote   = ""
+  , mmotivation = ""
+  , mhint= ""
   }
 
 short = ModeKind
@@ -292,7 +303,8 @@ short = ModeKind
   , mendMsg = []
   , mrules  = ""
   , mdesc   = "See all short scenarios!"
-  , mnote   = ""
+  , mmotivation = ""
+  , mhint= ""
   }
 
 crawlEmpty = ModeKind
@@ -304,7 +316,8 @@ crawlEmpty = ModeKind
   , mendMsg = []
   , mrules  = ""
   , mdesc   = "Enjoy the free space."
-  , mnote   = ""
+  , mmotivation = ""
+  , mhint= ""
   }
 
 crawlSurvival = ModeKind
@@ -316,7 +329,8 @@ crawlSurvival = ModeKind
   , mendMsg = []
   , mrules  = ""
   , mdesc   = "Lure the human intruders deeper and deeper."
-  , mnote   = ""
+  , mmotivation = ""
+  , mhint= ""
   }
 
 safariSurvival = ModeKind
@@ -328,7 +342,8 @@ safariSurvival = ModeKind
   , mendMsg = []
   , mrules  = ""
   , mdesc   = "In this enactment you'll discover the joys of being hunted among the most exquisite of Earth's flora and fauna, both animal and semi-intelligent."
-  , mnote   = ""
+  , mmotivation = ""
+  , mhint= ""
   }
 
 battle = ModeKind
@@ -340,7 +355,8 @@ battle = ModeKind
   , mendMsg = []
   , mrules  = ""
   , mdesc   = "Odds are stacked against those that unleash the horrors of abstraction."
-  , mnote   = ""
+  , mmotivation = ""
+  , mhint= ""
   }
 
 battleDefense = ModeKind
@@ -352,7 +368,8 @@ battleDefense = ModeKind
   , mendMsg = []
   , mrules  = ""
   , mdesc   = "Odds are stacked for those that breathe mathematics."
-  , mnote   = ""
+  , mmotivation = ""
+  , mhint= ""
   }
 
 battleSurvival = ModeKind
@@ -364,7 +381,8 @@ battleSurvival = ModeKind
   , mendMsg = []
   , mrules  = ""
   , mdesc   = "Odds are stacked for those that ally with the strongest."
-  , mnote   = ""
+  , mmotivation = ""
+  , mhint= ""
   }
 
 defense = ModeKind  -- perhaps a real scenario in the future
@@ -376,7 +394,8 @@ defense = ModeKind  -- perhaps a real scenario in the future
   , mendMsg = []
   , mrules  = ""
   , mdesc   = "Don't let human interlopers defile your abstract secrets and flee unpunished!"
-  , mnote   = ""
+  , mmotivation = ""
+  , mhint= ""
   }
 
 defenseEmpty = ModeKind
@@ -388,7 +407,8 @@ defenseEmpty = ModeKind
   , mendMsg = []
   , mrules  = ""
   , mdesc   = "Lord over."
-  , mnote   = ""
+  , mmotivation = ""
+  , mhint= ""
   }
 
 -- * Screensaver modes

--- a/GameDefinition/Content/ModeKind.hs
+++ b/GameDefinition/Content/ModeKind.hs
@@ -93,10 +93,10 @@ raid = ModeKind
               , (Defeated, "Regrettably, the other team snatched the grant, while you were busy contemplating natural phenomena. Science is a competitive sport, as sad as it sounds. It's not enough to make a discovery, you have to get there first.")
               , (Escape, "You've got hold of the machine! Think of the hours of fun taking it apart and putting it back together again! That's a great first step on your quest to solve the typing problems of the world.") ]
   , mrules  = T.unlines $
-      [ "* one level only"
-      , "* 2 heroes, foes that spawn"
-      , "* gather gold"
-      , "* find exit and escape ASAP"
+      [ "* One level only"
+      , "* Two heroes vs. spawned enemies"
+      , "* Gather gold"
+      , "* Find exit and escape ASAP"
       ]
   , mdesc   = "An incredibly advanced typing machine worth 100 gold is buried at the exit of this maze. Be the first to find it and fund a research team that makes typing accurate and dependable forever."
   , mnote   = "In addition to initiating the (loose) game plot, this scenario serves as an introductory tutorial. There is only one level. Relax, explore, gather loot, find the exit and escape. With some luck, you won't even need to fight anything or use any items. Feel free to scout with only one of the heroes and keep the other one immobile, e.g., standing guard over the squad's shared inventory stash. If in grave danger, retreat with the scout to join forces with the guard. The more gold collected and the faster the victory, the higher the score."
@@ -111,10 +111,10 @@ brawl = ModeKind  -- sparse melee in daylight, with shade for melee ambush
   , mendMsg = [ (Killed, "The inquisitive scholars turned out to be envious of our deep insight to the point of outright violence. It would still not result in such a defeat and recanting of our thesis if we figured out to use terrain to protect us from missiles or even completely hide our presence. It would also help if we honourably kept our ground together to the end, at the same time preventing the overwhelming enemy forces from brutishly ganging up on our modest-sized, though valiant, research team.")
               , (Conquer, "That's settled: local compactness *is* necessary for relative completeness, given the assumptions.") ]
   , mrules  = T.unlines $
-      [ "* one level only"
-      , "* 3 heroes, 3 human foes"
-      , "* avoid losses"
-      , "* incapacitate all foes ASAP"
+      [ "* One level only"
+      , "* Three heroes vs. Three human enemies"
+      , "* Minimize losses"
+      , "* Incapacitate all enemies ASAP"
       ]
   , mdesc   = "Your research team disagrees over a drink with some gentlemen scientists about premises of a relative completeness theorem and there's only one way to settle that. Remember to keep your party together when opponents are spotted, or they might be tempted to silence solitary disputants one by one and so win the altercation."
   , mnote   = "In addition to advancing the game plot, this scenario trains melee, squad formation and stealth. If you get beaten, ponder the hints from the defeat message. The battle is completely symmetric, both in numbers, goals and squad capabilities (e.g., only the pointman moves, while all others either melee or wait). Observe and mimic the enemies and savour the fairness --- you won't find any in the main crawl scenario that follows."
@@ -130,9 +130,9 @@ crawl = ModeKind
               , (Escape, "It's better to live to tell the tale than to choke on more than one can swallow. There was no more exquisite cultural artifacts and glorious scientific wonders in these forbidding tunnels anyway. Or were there?") ]
   , mrules  = T.unlines $
       [ "* many levels"
-      , "* 3 heroes, foes that spawn"
-      , "* gather gold, gems and elixirs"
-      , "* find exit and escape ASAP"
+      , "* Three heroes vs. spawned enemies"
+      , "* Gather gold, gems and elixirs"
+      , "* Find exit and escape ASAP"
       ]
   , mdesc   = "Enjoy the peaceful seclusion of these cold austere tunnels, but don't let wanton curiosity, greed and the ever-creeping abstraction madness keep you down there for too long. If you find survivors (whole or perturbed or segmented) of the past scientific missions, exercise extreme caution and engage or ignore at your discretion."
   , mnote   = "This is the main, longest and most replayable scenario of the game. If you keep dying, attempt the next game modes as a breather (perhaps at lowered difficulty). They fill the gaps in the plot and teach particular skills that may come in handy and help you discover new tactics of your own or come up with a strategy for staving off the attrition."
@@ -154,10 +154,10 @@ shootout = ModeKind  -- sparse ranged in daylight
   , mcaves  = cavesShootout
   , mendMsg = []
   , mrules  = T.unlines $
-      [ "* one level only"
-      , "* 3 heroes, 3 human foes"
-      , "* avoid losses"
-      , "* incapacitate all foes ASAP"
+      [ "* One level only"
+      , "* Three heroes vs. Three human enemies"
+      , "* Minimize losses"
+      , "* Incapacitate all enemies ASAP"
       ]
   , mdesc   = "Whose arguments are most striking and whose ideas fly fastest? Let's scatter up, attack the problems from different angles and find out."
   , mnote   = "This scenario is a flashback, picking the plot up where brawl (2) left it. It also teaches specifically the ranged combat skill in the simplified setup of fully symmetric battle. Try to come up with the best squad formation for this tactical challenge. Don't despair if you run out of ammo, because if you aim truly, enemy has few hit points left at this point. In turn, when trying to avoid enemy projectiles, you can display the trajectory of any soaring entity by pointing it with the crosshair in aiming mode."
@@ -171,10 +171,10 @@ hunt = ModeKind  -- melee vs ranged with reaction fire in daylight
   , mcaves  = cavesHunt
   , mendMsg = []
   , mrules  = T.unlines $
-      [ "* one level only"
-      , "* 7 heroes, 7 human foes that shoot concurrently"
-      , "* avoid losses"
-      , "* incapacitate all foes ASAP"
+      [ "* One level only"
+      , "* Seven heroes vs. seven human enemies capable of concurrent action"
+      , "* Minimize losses"
+      , "* Incapacitate all enemies ASAP"
       ]
   , mdesc   = "Who is the hunter and who is the prey?"
   , mnote   = "This is yet another reminiscence of the events that led to the long crawl adventure. This episode is quite a tactical challenge, because enemies are allowed to fling their ammo simultaneously at you team, which has no such capacities and focuses on melee combat instead. Act accordingly."
@@ -188,11 +188,11 @@ escape = ModeKind  -- asymmetric ranged and stealth race at night
   , mcaves  = cavesEscape
   , mendMsg = []
   , mrules  = T.unlines $
-      [ "* one level only"
-      , "* 3 heroes, 7 human foes that shoot concurrently"
-      , "* avoid losses"
-      , "* gather gems"
-      , "* find exit and escape ASAP"
+      [ "* One level only"
+      , "* Three heroes vs. seven human enemies capable of concurrent action"
+      , "* Minimize losses"
+      , "* Gather gems"
+      , "* Find exit and escape ASAP"
       ]
   , mdesc   = "Dwelling into dark matters is dangerous, so avoid the crowd of firebrand disputants, catch any gems of thought, find a way out and bring back a larger team to shed new light on the field."
   , mnote   = ""
@@ -206,10 +206,10 @@ zoo = ModeKind  -- asymmetric crowd melee at night
   , mcaves  = cavesZoo
   , mendMsg = []
   , mrules  = T.unlines $
-      [ "* one level only"
-      , "* 5 heroes, many foes"
-      , "* avoid losses"
-      , "* incapacitate all foes ASAP"
+      [ "* One level only"
+      , "* Five heroes vs. many enemies"
+      , "* Minimize losses"
+      , "* Incapacitate all enemies ASAP"
       ]
   , mdesc   = "The heat of the dispute reaches the nearby Wonders of Science and Nature exhibition, igniting greenery, nets and cages. Crazed animals must be dissuaded from ruining precious scientific equipment and setting back the otherwise fruitful exchange of ideas."
   , mnote   = ""
@@ -231,10 +231,10 @@ ambush = ModeKind  -- dense ranged with reaction fire vs melee at night
   , mcaves  = cavesAmbush
   , mendMsg = []
   , mrules  = T.unlines $
-      [ "* one level only"
-      , "* 3 heroes that shoot concurrently, unspecified human foes"
-      , "* avoid losses"
-      , "* assert control of the situation ASAP"
+      [ "* One level only"
+      , "* Three heroes capable of concurrent action vs. unspecified number of human enemies"
+      , "* Minimize losses"
+      , "* Assert control of the situation ASAP"
       ]
   , mdesc   = "Prevent hijacking of your ideas at all cost! Be stealthy, be observant, be aggressive. Fast execution is what makes or breaks a creative team."
   , mnote   = ""
@@ -248,10 +248,10 @@ safari = ModeKind  -- Easter egg available only via screensaver
   , mcaves  = cavesSafari
   , mendMsg = []
   , mrules  = T.unlines $
-      [ "* three levels"
-      , "* many friends that move concurrently, many foes"
-      , "* avoid losses"
-      , "* find exit and escape ASAP"
+      [ "* Three levels"
+      , "* Many allies capable of concurrent action vs. many enemies capable of concurrent action"
+      , "* Minimize losses"
+      , "* Find exit and escape ASAP"
       ]
   , mdesc   = "\"In this enactment you'll discover the joys of hunting the most exquisite of Earth's flora and fauna, both animal and semi-intelligent. Exit at the bottommost level.\" This is a drama script recovered from a monster nest debris."
   , mnote   = ""

--- a/GameDefinition/Content/ModeKind.hs
+++ b/GameDefinition/Content/ModeKind.hs
@@ -239,7 +239,7 @@ ambush = ModeKind  -- dense ranged with reaction fire vs melee at night
   , mendMsg = []
   , mrules  = T.unlines $
       [ "* One level only"
-      , "* Three heroes capable of concurrent attacks vs. Unknown number and identity of human enemies"
+      , "* Three heroes with concurrent attacks vs. Unknown number and identity of foes"
       , "* Minimize losses"
       , "* Assert control of the situation ASAP"
       ]

--- a/GameDefinition/Content/ModeKind.hs
+++ b/GameDefinition/Content/ModeKind.hs
@@ -94,7 +94,7 @@ raid = ModeKind
               , (Escape, "You've got hold of the machine! Think of the hours of fun taking it apart and putting it back together again! That's a great first step on your quest to solve the typing problems of the world.") ]
   , mrules  = T.unlines $
       [ "* One level only"
-      , "* Two heroes vs. spawned enemies"
+      , "* Two heroes vs. Spawned enemies"
       , "* Gather gold"
       , "* Find exit and escape ASAP"
       ]
@@ -132,7 +132,7 @@ crawl = ModeKind
               , (Escape, "It's better to live to tell the tale than to choke on more than one can swallow. There was no more exquisite cultural artifacts and glorious scientific wonders in these forbidding tunnels anyway. Or were there?") ]
   , mrules  = T.unlines $
       [ "* Many levels"
-      , "* Three heroes vs. spawned enemies"
+      , "* Three heroes vs. Spawned enemies"
       , "* Gather gold, gems and elixirs"
       , "* Find exit and escape ASAP"
       ]
@@ -176,13 +176,13 @@ hunt = ModeKind  -- melee vs ranged with reaction fire in daylight
   , mendMsg = []
   , mrules  = T.unlines $
       [ "* One level only"
-      , "* Seven heroes vs. seven human enemies capable of concurrent action"
+      , "* Seven heroes vs. Seven human enemies capable of concurrent action"
       , "* Minimize losses"
       , "* Incapacitate all enemies ASAP"
       ]
   , mdesc   = "Who is the hunter and who is the prey?"
-  , mmotivation = "This is yet another reminiscence of the events that led to the long crawl adventure. This episode is quite a tactical challenge, because enemies are allowed to fling their ammo simultaneously at your team, which has no such capacities and focuses on melee combat instead. Act accordingly."
-  , mhint= ""
+  , mmotivation = "This is yet another reminiscence of the events that led to the long crawl adventure. This episode is quite a tactical challenge, because enemies are allowed to fling their ammo simultaneously at your team, which has no such capacities."
+  , mhint= "Try not to outshoot the enemy, but to instead focus more on melee tactics."
   }
 
 escape = ModeKind  -- asymmetric ranged and stealth race at night
@@ -194,7 +194,7 @@ escape = ModeKind  -- asymmetric ranged and stealth race at night
   , mendMsg = []
   , mrules  = T.unlines $
       [ "* One level only"
-      , "* Three heroes vs. seven human enemies capable of concurrent action"
+      , "* Three heroes vs. Seven human enemies capable of concurrent attacks"
       , "* Minimize losses"
       , "* Gather gems"
       , "* Find exit and escape ASAP"
@@ -213,7 +213,7 @@ zoo = ModeKind  -- asymmetric crowd melee at night
   , mendMsg = []
   , mrules  = T.unlines $
       [ "* One level only"
-      , "* Five heroes vs. many enemies"
+      , "* Five heroes vs. Many enemies"
       , "* Minimize losses"
       , "* Incapacitate all enemies ASAP"
       ]
@@ -239,7 +239,7 @@ ambush = ModeKind  -- dense ranged with reaction fire vs melee at night
   , mendMsg = []
   , mrules  = T.unlines $
       [ "* One level only"
-      , "* Three heroes capable of concurrent action vs. unspecified number of human enemies"
+      , "* Three heroes capable of concurrent attacks vs. Unknown number and identity of human enemies"
       , "* Minimize losses"
       , "* Assert control of the situation ASAP"
       ]
@@ -257,7 +257,7 @@ safari = ModeKind  -- Easter egg available only via screensaver
   , mendMsg = []
   , mrules  = T.unlines $
       [ "* Three levels"
-      , "* Many allies capable of concurrent action vs. many enemies capable of concurrent action"
+      , "* Many teammates capable of concurrent action vs. Many enemies"
       , "* Minimize losses"
       , "* Find exit and escape ASAP"
       ]

--- a/definition-src/Game/LambdaHack/Content/ModeKind.hs
+++ b/definition-src/Game/LambdaHack/Content/ModeKind.hs
@@ -31,17 +31,18 @@ import           Game.LambdaHack.Definition.Defs
 
 -- | Game mode specification.
 data ModeKind = ModeKind
-  { msymbol :: Char            -- ^ a symbol
-  , mname   :: Text            -- ^ short description
-  , mfreq   :: Freqs ModeKind  -- ^ frequency within groups
-  , mroster :: Roster          -- ^ players taking part in the game
-  , mcaves  :: Caves           -- ^ arena of the game
-  , mendMsg :: [(Outcome, Text)]
-                               -- ^ messages displayed at particular game ends;
-                               --   if no message, the screen is skipped
-  , mrules  :: Text            -- ^ rules note
-  , mdesc   :: Text            -- ^ description
-  , mnote   :: Text            -- ^ meta note
+  { msymbol     :: Char            -- ^ a symbol
+  , mname       :: Text            -- ^ short description
+  , mfreq       :: Freqs ModeKind  -- ^ frequency within groups
+  , mroster     :: Roster          -- ^ players taking part in the game
+  , mcaves      :: Caves           -- ^ arena of the game
+  , mendMsg     :: [(Outcome, Text)]
+                                   -- ^ messages displayed at particular game ends;
+                                   --   if no message, the screen is skipped
+  , mrules      :: Text            -- ^ rules note
+  , mdesc       :: Text            -- ^ description
+  , mmotivation :: Text            -- ^ message on why/when mode should be played
+  , mhint       :: Text            -- ^ hints in case the player faces difficulties 
   }
   deriving Show
 

--- a/engine-src/Game/LambdaHack/Client/UI/DisplayAtomicM.hs
+++ b/engine-src/Game/LambdaHack/Client/UI/DisplayAtomicM.hs
@@ -490,9 +490,6 @@ displayRespUpdAtomicUI cmd = case cmd of
     recordHistory
     msgAdd MsgWarning $ "New game started in" <+> mname mode <+> "mode."
     msgAdd MsgAdmin $ mdesc mode
-    unless (T.null $ mnote mode) $ do
-      msgAdd MsgWarning "\nNote:"
-      msgAdd MsgAdmin $ mnote mode
     let desc = cdesc $ okind cocave $ lkind lvl
     unless (T.null desc) $ do
       msgLnAdd MsgFocus "You take in your surroundings."
@@ -531,9 +528,6 @@ displayRespUpdAtomicUI cmd = case cmd of
       mode <- getGameMode
       msgAdd MsgAlert $ "Continuing" <+> mname mode <> "."
       msgAdd0 MsgPrompt $ mdesc mode
-      unless (T.null $ mnote mode) $ do
-        msgAdd0 MsgWarning "\nNote:"
-        msgAdd0 MsgAdmin $ mnote mode
       let desc = cdesc $ okind cocave $ lkind lvl
       unless (T.null desc) $ do
         msgLnAdd0 MsgPromptFocus "You remember your surroundings."

--- a/engine-src/Game/LambdaHack/Client/UI/HandleHumanGlobalM.hs
+++ b/engine-src/Game/LambdaHack/Client/UI/HandleHumanGlobalM.hs
@@ -1716,10 +1716,10 @@ challengesMenuHuman cmdSemInCxtOfKM = do
       width = if isSquareFont propFont then 42 else 84
       duplicateEOL '\n' = "\n\n"
       duplicateEOL c = T.singleton c
-      blurb = splitAttrString width $ textToAS 
-              $ mmotivation gameMode
-                <> duplicateEOL '\n'
-                <> mrules gameMode
+  
+      blurb = splitAttrString width $ textToAS $
+        T.concatMap duplicateEOL (mmotivation gameMode <> "\n")
+        <> mrules gameMode
                    
   generateMenu cmdSemInCxtOfKM blurb kds gameInfo "challenge"
 

--- a/engine-src/Game/LambdaHack/Client/UI/HandleHumanGlobalM.hs
+++ b/engine-src/Game/LambdaHack/Client/UI/HandleHumanGlobalM.hs
@@ -1555,7 +1555,7 @@ generateMenu cmdSemInCxtOfKM blurb kds gameInfo menuName = do
   CCUI{coscreen=ScreenContent{rwidth, rheight, rmainMenuLine}} <-
     getsSession sccui
   FontSetup{..} <- getFontSetup
-  let offset = if isSquareFont propFont || length blurb <= 1 then 2 else -8
+  let offset = 2
       bindings =  -- key bindings to display
         let fmt (k, (d, _)) =
               ( Just k
@@ -1580,8 +1580,8 @@ generateMenu cmdSemInCxtOfKM blurb kds gameInfo menuName = do
       introLen = length blurb
       introMaxLen = maximum $ 30 : map (textSize monoFont . attrLine) blurb
       introOv = map (first $ K.PointUI (2 * rwidth - introMaxLen - offset))
-                $ zip [max 0 (rheight - introLen - 1) ..] blurb
-      ov = EM.insertWith (++) propFont introOv
+                $ zip [max 0 (rheight - introLen - offset) ..] blurb
+      ov = EM.insertWith (++) monoFont introOv
            $ EM.singleton squareFont $ offsetOverlayX menuOvLines
   ekm <- displayChoiceScreen menuName ColorFull True
                              (menuToSlideshow (ov, kyxs)) [K.escKM]
@@ -1716,11 +1716,11 @@ challengesMenuHuman cmdSemInCxtOfKM = do
       width = if isSquareFont propFont then 42 else 84
       duplicateEOL '\n' = "\n\n"
       duplicateEOL c = T.singleton c
-      blurb = splitAttrString width $ textToAS $ T.concatMap duplicateEOL
-              $ mdesc gameMode
-                <> if T.null (mnote gameMode)
-                   then "\n"  -- whitespace compensates for the lack of note
-                   else "\n[Note: " <> mnote gameMode <> "]"
+      blurb = splitAttrString width $ textToAS 
+              $ mnote gameMode
+                <> duplicateEOL '\n'
+                <> mrules gameMode
+                   
   generateMenu cmdSemInCxtOfKM blurb kds gameInfo "challenge"
 
 -- * GameScenarioIncr

--- a/engine-src/Game/LambdaHack/Client/UI/HandleHumanGlobalM.hs
+++ b/engine-src/Game/LambdaHack/Client/UI/HandleHumanGlobalM.hs
@@ -1717,7 +1717,7 @@ challengesMenuHuman cmdSemInCxtOfKM = do
       duplicateEOL '\n' = "\n\n"
       duplicateEOL c = T.singleton c
       blurb = splitAttrString width $ textToAS 
-              $ mnote gameMode
+              $ mmotivation gameMode
                 <> duplicateEOL '\n'
                 <> mrules gameMode
                    


### PR DESCRIPTION
I've reduced the text on the mode select screen down to only a motivation block and rules. 
I split the note text that was previously displayed into smaller fields, mmotivation, and mhint. 
This doesn't yet use the text in mhint which still remains to be placed somewhere. So far discussion has suggested perhaps placing the mhint text in help screen for example.