### PR TITLE
Teammate cycling keybinding changes

### DIFF
--- a/GameDefinition/game-src/Client/UI/Content/Input.hs
+++ b/GameDefinition/game-src/Client/UI/Content/Input.hs
@@ -62,7 +62,7 @@ standardKeysAndMouse = InputContentRaw $ map evalKeyDef $
   , ("space", ( [CmdMinimal, CmdMeta]
               , "clear messages and show history"
               , ExecuteIfClear LastHistory ))
-  , ("Tab", ( [CmdMinimal]
+  , ("Tab", ( [CmdMinimal, CmdMove]
             , "cycle among all party members"
             , MemberCycle Forward))
       -- listed here to keep proper order

--- a/GameDefinition/game-src/Client/UI/Content/Input.hs
+++ b/GameDefinition/game-src/Client/UI/Content/Input.hs
@@ -62,18 +62,18 @@ standardKeysAndMouse = InputContentRaw $ map evalKeyDef $
   , ("space", ( [CmdMinimal, CmdMeta]
               , "clear messages and show history"
               , ExecuteIfClear LastHistory ))
-  , ("Tab", ( [CmdMove]
+  , ("Tab", ( [CmdMinimal]
             , "cycle among all party members"
             , MemberCycle Forward))
       -- listed here to keep proper order
   , ("BackTab", ( [CmdMove]
-            , "cycle among all party members(reversed)"
+            , "cycle backwards among all party members"
             , MemberCycle Backward))
-  , ("A-Tab", ( [CmdMinimal, CmdMove]
+  , ("A-Tab", ( [CmdMove]
                 , "cycle among party members on the level"
                 , MemberCycleLevel Forward))
-  , ("A-BackTab", ( [CmdMinimal, CmdMove]
-                , "cycle among party members on the level(reversed)"
+  , ("A-BackTab", ( [CmdMove]
+                , "cycle backwards among party members on the level"
                 , MemberCycleLevel Backward))
   , ("*", ( [CmdMinimal, CmdAim]
           , "cycle crosshair among enemies"

--- a/GameDefinition/game-src/Client/UI/Content/Input.hs
+++ b/GameDefinition/game-src/Client/UI/Content/Input.hs
@@ -63,12 +63,12 @@ standardKeysAndMouse = InputContentRaw $ map evalKeyDef $
               , "clear messages and show history"
               , ExecuteIfClear LastHistory ))
   , ("Tab", ( [CmdMove]
-            , "cycle among party members on the level"
+            , "cycle among all party members"
             , MemberCycle ))
       -- listed here to keep proper order
   , ("BackTab", ( [CmdMinimal, CmdMove]
-              , "cycle among all party members"
-              , MemberBack ))
+                , "cycle among party members on the level"
+                , MemberBack ))
   , ("*", ( [CmdMinimal, CmdAim]
           , "cycle crosshair among enemies"
           , AimEnemy ))

--- a/GameDefinition/game-src/Client/UI/Content/Input.hs
+++ b/GameDefinition/game-src/Client/UI/Content/Input.hs
@@ -150,8 +150,8 @@ standardKeysAndMouse = InputContentRaw $ map evalKeyDef $
             , Macro ["C-KP_Begin", "A-v"] ))
 
   -- Aiming
-  , ("+", ([CmdAim], "swerve the aiming line", EpsIncr True))
-  , ("-", ([CmdAim], "unswerve the aiming line", EpsIncr False))
+  , ("+", ([CmdAim], "swerve the aiming line", EpsIncr Forward))
+  , ("-", ([CmdAim], "unswerve the aiming line", EpsIncr Backward))
   , ("\\", ([CmdAim], "cycle aiming modes", AimFloor))
   , ("C-?", ( [CmdAim]
             , "set crosshair to nearest unknown spot"

--- a/GameDefinition/game-src/Client/UI/Content/Input.hs
+++ b/GameDefinition/game-src/Client/UI/Content/Input.hs
@@ -64,11 +64,11 @@ standardKeysAndMouse = InputContentRaw $ map evalKeyDef $
               , ExecuteIfClear LastHistory ))
   , ("Tab", ( [CmdMove]
             , "cycle among all party members"
-            , MemberCycle ))
+            , MemberCycleForward))
       -- listed here to keep proper order
   , ("A-Tab", ( [CmdMinimal, CmdMove]
                 , "cycle among party members on the level"
-                , MemberBack ))
+                , MemberCycleForwardLevel))
   , ("*", ( [CmdMinimal, CmdAim]
           , "cycle crosshair among enemies"
           , AimEnemy ))

--- a/GameDefinition/game-src/Client/UI/Content/Input.hs
+++ b/GameDefinition/game-src/Client/UI/Content/Input.hs
@@ -64,17 +64,17 @@ standardKeysAndMouse = InputContentRaw $ map evalKeyDef $
               , ExecuteIfClear LastHistory ))
   , ("Tab", ( [CmdMove]
             , "cycle among all party members"
-            , MemberCycleForward))
+            , MemberCycle Forward))
       -- listed here to keep proper order
   , ("BackTab", ( [CmdMove]
             , "cycle among all party members(reversed)"
-            , MemberCycleBackward))
+            , MemberCycle Backward))
   , ("A-Tab", ( [CmdMinimal, CmdMove]
                 , "cycle among party members on the level"
-                , MemberCycleForwardLevel))
+                , MemberCycleLevel Forward))
   , ("A-BackTab", ( [CmdMinimal, CmdMove]
                 , "cycle among party members on the level(reversed)"
-                , MemberCycleBackwardLevel))
+                , MemberCycleLevel Backward))
   , ("*", ( [CmdMinimal, CmdAim]
           , "cycle crosshair among enemies"
           , AimEnemy ))

--- a/GameDefinition/game-src/Client/UI/Content/Input.hs
+++ b/GameDefinition/game-src/Client/UI/Content/Input.hs
@@ -66,7 +66,7 @@ standardKeysAndMouse = InputContentRaw $ map evalKeyDef $
             , "cycle among all party members"
             , MemberCycle ))
       -- listed here to keep proper order
-  , ("BackTab", ( [CmdMinimal, CmdMove]
+  , ("A-Tab", ( [CmdMinimal, CmdMove]
                 , "cycle among party members on the level"
                 , MemberBack ))
   , ("*", ( [CmdMinimal, CmdAim]

--- a/GameDefinition/game-src/Client/UI/Content/Input.hs
+++ b/GameDefinition/game-src/Client/UI/Content/Input.hs
@@ -66,9 +66,15 @@ standardKeysAndMouse = InputContentRaw $ map evalKeyDef $
             , "cycle among all party members"
             , MemberCycleForward))
       -- listed here to keep proper order
+  , ("BackTab", ( [CmdMove]
+            , "cycle among all party members(reversed)"
+            , MemberCycleBackward))
   , ("A-Tab", ( [CmdMinimal, CmdMove]
                 , "cycle among party members on the level"
                 , MemberCycleForwardLevel))
+  , ("A-BackTab", ( [CmdMinimal, CmdMove]
+                , "cycle among party members on the level(reversed)"
+                , MemberCycleBackwardLevel))
   , ("*", ( [CmdMinimal, CmdAim]
           , "cycle crosshair among enemies"
           , AimEnemy ))

--- a/definition-src/Game/LambdaHack/Definition/Defs.hs
+++ b/definition-src/Game/LambdaHack/Definition/Defs.hs
@@ -7,6 +7,7 @@ module Game.LambdaHack.Definition.Defs
   , CStore(..), ppCStore, ppCStoreIn, verbCStore
   , SLore(..), ItemDialogMode(..), ppSLore, headingSLore
   , ppItemDialogMode, ppItemDialogModeIn, ppItemDialogModeFrom
+  , Direction(..)
   ) where
 
 import Prelude ()
@@ -153,3 +154,10 @@ ppItemDialogModeIn c = let (tIn, t) = ppItemDialogMode c in tIn <+> t
 
 ppItemDialogModeFrom :: ItemDialogMode -> Text
 ppItemDialogModeFrom c = let (_tIn, t) = ppItemDialogMode c in "from" <+> t
+
+data Direction = Forward | Backward
+  deriving (Show, Read, Eq, Ord, Generic)
+
+instance NFData Direction
+
+instance Binary Direction

--- a/engine-src/Game/LambdaHack/Client/UI/HandleHelperM.hs
+++ b/engine-src/Game/LambdaHack/Client/UI/HandleHelperM.hs
@@ -2,7 +2,7 @@
 module Game.LambdaHack.Client.UI.HandleHelperM
   ( FailError, showFailError, MError, mergeMError, FailOrCmd, failWith
   , failSer, failMsg, weaveJust
-  , memberCycle, memberBack, partyAfterLeader, pickLeader, pickLeaderWithPointer
+  , memberCycle, memberCycleLevel, partyAfterLeader, pickLeader, pickLeaderWithPointer
   , itemOverlay, skillsOverlay, placesFromState, placesOverlay
   , pickNumber, lookAtItems, lookAtStash, lookAtPosition
   , displayItemLore, viewLoreItems, cycleLore, spoilsBlurb
@@ -96,10 +96,9 @@ weaveJust :: FailOrCmd a -> Either MError a
 weaveJust (Left ferr) = Left $ Just ferr
 weaveJust (Right a) = Right a
 
-
--- | Switches current member to the previous in the whole dungeon, wrapping.
-memberBack :: MonadClientUI m => Bool -> m MError
-memberBack verbose = do
+-- | Switches current member to the next on the level, if any, wrapping.
+memberCycleLevel :: MonadClientUI m => Bool -> m MError
+memberCycleLevel verbose = do
   side <- getsClient sside
   fact <- getsState $ (EM.! side) . sfactionD
   lidV <- viewedLevelUI
@@ -117,7 +116,7 @@ memberBack verbose = do
                                 `swith` (leader, np, b)) ()
       return Nothing
 
--- | Switches current member to the next on the level, if any, wrapping.
+-- | Switches current member to the previous in the whole dungeon, wrapping.
 memberCycle :: MonadClientUI m => Bool -> m MError
 memberCycle verbose = do
   side <- getsClient sside
@@ -197,7 +196,7 @@ pickLeaderWithPointer = do
   K.PointUI x y <- getsSession spointer
   let (px, py) = (x `div` 2, y - K.mapStartY)
   -- Pick even if no space in status line for the actor's symbol.
-  if | py == rheight - 2 && px == 0 -> memberBack True
+  if | py == rheight - 2 && px == 0 -> memberCycleLevel True
      | py == rheight - 2 ->
          case drop (px - 1) viewed of
            [] -> return Nothing

--- a/engine-src/Game/LambdaHack/Client/UI/HandleHelperM.hs
+++ b/engine-src/Game/LambdaHack/Client/UI/HandleHelperM.hs
@@ -124,7 +124,7 @@ memberBack verbose = do
   leader <- getLeaderUI
   hs <- partyAfterLeader leader
   let (autoDun, _) = autoDungeonLevel fact
-  case reverse hs of
+  case hs of
     _ | autoDun -> failMsg $ showReqFailure NoChangeDunLeader
     [] -> failMsg "no other member in the party"
     (np, b, _) : _ -> do

--- a/engine-src/Game/LambdaHack/Client/UI/HandleHelperM.hs
+++ b/engine-src/Game/LambdaHack/Client/UI/HandleHelperM.hs
@@ -96,9 +96,10 @@ weaveJust :: FailOrCmd a -> Either MError a
 weaveJust (Left ferr) = Left $ Just ferr
 weaveJust (Right a) = Right a
 
--- | Switches current member to the next on the level, if any, wrapping.
-memberCycle :: MonadClientUI m => Bool -> m MError
-memberCycle verbose = do
+
+-- | Switches current member to the previous in the whole dungeon, wrapping.
+memberBack :: MonadClientUI m => Bool -> m MError
+memberBack verbose = do
   side <- getsClient sside
   fact <- getsState $ (EM.! side) . sfactionD
   lidV <- viewedLevelUI
@@ -116,9 +117,9 @@ memberCycle verbose = do
                                 `swith` (leader, np, b)) ()
       return Nothing
 
--- | Switches current member to the previous in the whole dungeon, wrapping.
-memberBack :: MonadClientUI m => Bool -> m MError
-memberBack verbose = do
+-- | Switches current member to the next on the level, if any, wrapping.
+memberCycle :: MonadClientUI m => Bool -> m MError
+memberCycle verbose = do
   side <- getsClient sside
   fact <- getsState $ (EM.! side) . sfactionD
   leader <- getLeaderUI

--- a/engine-src/Game/LambdaHack/Client/UI/HandleHelperM.hs
+++ b/engine-src/Game/LambdaHack/Client/UI/HandleHelperM.hs
@@ -202,7 +202,7 @@ pickLeaderWithPointer = do
   K.PointUI x y <- getsSession spointer
   let (px, py) = (x `div` 2, y - K.mapStartY)
   -- Pick even if no space in status line for the actor's symbol.
-  if | py == rheight - 2 && px == 0 -> memberCycleLevel True Forward
+  if | py == rheight - 2 && px == 0 -> memberCycle True Forward
      | py == rheight - 2 ->
          case drop (px - 1) viewed of
            [] -> return Nothing

--- a/engine-src/Game/LambdaHack/Client/UI/HandleHumanLocalM.hs
+++ b/engine-src/Game/LambdaHack/Client/UI/HandleHumanLocalM.hs
@@ -9,7 +9,7 @@ module Game.LambdaHack.Client.UI.HandleHumanLocalM
   , chooseItemHuman, chooseItemDialogMode
   , chooseItemProjectHuman, chooseItemApplyHuman
   , psuitReq, triggerSymbols, pickLeaderHuman, pickLeaderWithPointerHuman
-  , memberCycleHuman, memberBackHuman
+  , memberCycleHuman, memberCycleLevelHuman
   , selectActorHuman, selectNoneHuman, selectWithPointerHuman
   , repeatHuman, repeatHumanTransition
   , repeatLastHuman, repeatLastHumanTransition
@@ -629,14 +629,14 @@ pickLeaderWithPointerHuman = pickLeaderWithPointer
 -- * MemberCycle
 
 -- | Switch current member to the next on the viewed level, if any, wrapping.
-memberCycleHuman :: MonadClientUI m => m MError
-memberCycleHuman = memberCycle True
+memberCycleLevelHuman :: MonadClientUI m => m MError
+memberCycleLevelHuman = memberCycleLevel True
 
 -- * MemberBack
 
 -- | Switch current member to the previous in the whole dungeon, wrapping.
-memberBackHuman :: MonadClientUI m => m MError
-memberBackHuman = memberBack True
+memberCycleHuman :: MonadClientUI m =>  m MError
+memberCycleHuman = memberCycle True
 
 -- * SelectActor
 

--- a/engine-src/Game/LambdaHack/Client/UI/HandleHumanLocalM.hs
+++ b/engine-src/Game/LambdaHack/Client/UI/HandleHumanLocalM.hs
@@ -630,13 +630,13 @@ pickLeaderWithPointerHuman = pickLeaderWithPointer
 
 -- | Switch current member to the next on the viewed level, if any, wrapping.
 memberCycleLevelHuman :: MonadClientUI m => Direction -> m MError
-memberCycleLevelHuman direction = memberCycleLevel True direction
+memberCycleLevelHuman = memberCycleLevel True 
 
 -- * MemberBack
 
 -- | Switch current member to the previous in the whole dungeon, wrapping.
 memberCycleHuman :: MonadClientUI m => Direction -> m MError
-memberCycleHuman direction = memberCycle True direction
+memberCycleHuman = memberCycle True
 
 -- * SelectActor
 
@@ -1136,7 +1136,10 @@ epsIncrHuman d = do
   saimMode <- getsSession saimMode
   lidV <- viewedLevelUI
   modifySession $ \sess -> sess {saimMode = Just $ AimMode lidV}
-  modifyClient $ \cli -> cli {seps = seps cli + case d of { Forward -> 1; Backward -> -1}}
+  let sepsDelta = case d of
+        Forward -> 1
+        Backward -> -1
+  modifyClient $ \cli -> cli {seps = seps cli + sepsDelta}
   invalidateBfsPathAll
   flashAiming
   modifySession $ \sess -> sess {saimMode}

--- a/engine-src/Game/LambdaHack/Client/UI/HandleHumanLocalM.hs
+++ b/engine-src/Game/LambdaHack/Client/UI/HandleHumanLocalM.hs
@@ -630,7 +630,7 @@ pickLeaderWithPointerHuman = pickLeaderWithPointer
 
 -- | Switch current member to the next on the viewed level, if any, wrapping.
 memberCycleLevelHuman :: MonadClientUI m => Direction -> m MError
-memberCycleLevelHuman = memberCycleLevel True 
+memberCycleLevelHuman = memberCycleLevel True
 
 -- * MemberBack
 

--- a/engine-src/Game/LambdaHack/Client/UI/HandleHumanLocalM.hs
+++ b/engine-src/Game/LambdaHack/Client/UI/HandleHumanLocalM.hs
@@ -629,16 +629,14 @@ pickLeaderWithPointerHuman = pickLeaderWithPointer
 -- * MemberCycle
 
 -- | Switch current member to the next on the viewed level, if any, wrapping.
-memberCycleLevelHuman :: MonadClientUI m => HumanCmd.CycleDirection -> m MError
-memberCycleLevelHuman HumanCmd.Forward = memberCycleLevel True True
-memberCycleLevelHuman HumanCmd.Backward = memberCycleLevel True False
+memberCycleLevelHuman :: MonadClientUI m => Direction -> m MError
+memberCycleLevelHuman direction = memberCycleLevel True direction
 
 -- * MemberBack
 
 -- | Switch current member to the previous in the whole dungeon, wrapping.
-memberCycleHuman :: MonadClientUI m => HumanCmd.CycleDirection -> m MError
-memberCycleHuman HumanCmd.Forward = memberCycle True True
-memberCycleHuman HumanCmd.Backward = memberCycle True False
+memberCycleHuman :: MonadClientUI m => Direction -> m MError
+memberCycleHuman direction = memberCycle True direction
 
 -- * SelectActor
 
@@ -1133,12 +1131,12 @@ aimAscendHuman k = do
 -- * EpsIncr
 
 -- | Tweak the @eps@ parameter of the aiming digital line.
-epsIncrHuman :: (MonadClient m, MonadClientUI m) => Bool -> m ()
-epsIncrHuman b = do
+epsIncrHuman :: (MonadClient m, MonadClientUI m) => Direction -> m ()
+epsIncrHuman d = do
   saimMode <- getsSession saimMode
   lidV <- viewedLevelUI
   modifySession $ \sess -> sess {saimMode = Just $ AimMode lidV}
-  modifyClient $ \cli -> cli {seps = seps cli + if b then 1 else -1}
+  modifyClient $ \cli -> cli {seps = seps cli + case d of { Forward -> 1; Backward -> -1}}
   invalidateBfsPathAll
   flashAiming
   modifySession $ \sess -> sess {saimMode}

--- a/engine-src/Game/LambdaHack/Client/UI/HandleHumanLocalM.hs
+++ b/engine-src/Game/LambdaHack/Client/UI/HandleHumanLocalM.hs
@@ -629,14 +629,14 @@ pickLeaderWithPointerHuman = pickLeaderWithPointer
 -- * MemberCycle
 
 -- | Switch current member to the next on the viewed level, if any, wrapping.
-memberCycleLevelHuman :: MonadClientUI m => m MError
-memberCycleLevelHuman = memberCycleLevel True
+memberCycleLevelHuman :: MonadClientUI m => Bool -> m MError
+memberCycleLevelHuman forward = memberCycleLevel True forward
 
 -- * MemberBack
 
 -- | Switch current member to the previous in the whole dungeon, wrapping.
-memberCycleHuman :: MonadClientUI m =>  m MError
-memberCycleHuman = memberCycle True
+memberCycleHuman :: MonadClientUI m => Bool -> m MError
+memberCycleHuman forward = memberCycle True forward
 
 -- * SelectActor
 

--- a/engine-src/Game/LambdaHack/Client/UI/HandleHumanLocalM.hs
+++ b/engine-src/Game/LambdaHack/Client/UI/HandleHumanLocalM.hs
@@ -629,14 +629,16 @@ pickLeaderWithPointerHuman = pickLeaderWithPointer
 -- * MemberCycle
 
 -- | Switch current member to the next on the viewed level, if any, wrapping.
-memberCycleLevelHuman :: MonadClientUI m => Bool -> m MError
-memberCycleLevelHuman forward = memberCycleLevel True forward
+memberCycleLevelHuman :: MonadClientUI m => HumanCmd.CycleDirection -> m MError
+memberCycleLevelHuman HumanCmd.Forward = memberCycleLevel True True
+memberCycleLevelHuman HumanCmd.Backward = memberCycleLevel True False
 
 -- * MemberBack
 
 -- | Switch current member to the previous in the whole dungeon, wrapping.
-memberCycleHuman :: MonadClientUI m => Bool -> m MError
-memberCycleHuman forward = memberCycle True forward
+memberCycleHuman :: MonadClientUI m => HumanCmd.CycleDirection -> m MError
+memberCycleHuman HumanCmd.Forward = memberCycle True True
+memberCycleHuman HumanCmd.Backward = memberCycle True False
 
 -- * SelectActor
 

--- a/engine-src/Game/LambdaHack/Client/UI/HandleHumanM.hs
+++ b/engine-src/Game/LambdaHack/Client/UI/HandleHumanM.hs
@@ -135,7 +135,9 @@ cmdSemantics cmd = case cmd of
   PickLeader k -> Left <$> pickLeaderHuman k
   PickLeaderWithPointer -> Left <$> pickLeaderWithPointerHuman
   MemberCycleForwardLevel -> Left <$> memberCycleLevelHuman True
+  MemberCycleBackwardLevel -> Left <$> memberCycleLevelHuman False 
   MemberCycleForward -> Left <$> memberCycleHuman True
+  MemberCycleBackward -> Left <$> memberCycleHuman False
   SelectActor -> addNoError selectActorHuman
   SelectNone -> addNoError selectNoneHuman
   SelectWithPointer -> Left <$> selectWithPointerHuman

--- a/engine-src/Game/LambdaHack/Client/UI/HandleHumanM.hs
+++ b/engine-src/Game/LambdaHack/Client/UI/HandleHumanM.hs
@@ -134,10 +134,8 @@ cmdSemantics cmd = case cmd of
   ChooseItemApply ts -> Left <$> chooseItemApplyHuman ts
   PickLeader k -> Left <$> pickLeaderHuman k
   PickLeaderWithPointer -> Left <$> pickLeaderWithPointerHuman
-  MemberCycleForwardLevel -> Left <$> memberCycleLevelHuman True
-  MemberCycleBackwardLevel -> Left <$> memberCycleLevelHuman False 
-  MemberCycleForward -> Left <$> memberCycleHuman True
-  MemberCycleBackward -> Left <$> memberCycleHuman False
+  MemberCycle direction -> Left <$> memberCycleHuman direction
+  MemberCycleLevel direction -> Left <$> memberCycleLevelHuman direction
   SelectActor -> addNoError selectActorHuman
   SelectNone -> addNoError selectNoneHuman
   SelectWithPointer -> Left <$> selectWithPointerHuman

--- a/engine-src/Game/LambdaHack/Client/UI/HandleHumanM.hs
+++ b/engine-src/Game/LambdaHack/Client/UI/HandleHumanM.hs
@@ -134,8 +134,8 @@ cmdSemantics cmd = case cmd of
   ChooseItemApply ts -> Left <$> chooseItemApplyHuman ts
   PickLeader k -> Left <$> pickLeaderHuman k
   PickLeaderWithPointer -> Left <$> pickLeaderWithPointerHuman
-  MemberCycle -> Left <$> memberCycleHuman
-  MemberBack -> Left <$> memberBackHuman
+  MemberCycleForwardLevel -> Left <$> memberCycleLevelHuman
+  MemberCycleForward -> Left <$> memberCycleHuman
   SelectActor -> addNoError selectActorHuman
   SelectNone -> addNoError selectNoneHuman
   SelectWithPointer -> Left <$> selectWithPointerHuman

--- a/engine-src/Game/LambdaHack/Client/UI/HandleHumanM.hs
+++ b/engine-src/Game/LambdaHack/Client/UI/HandleHumanM.hs
@@ -134,8 +134,8 @@ cmdSemantics cmd = case cmd of
   ChooseItemApply ts -> Left <$> chooseItemApplyHuman ts
   PickLeader k -> Left <$> pickLeaderHuman k
   PickLeaderWithPointer -> Left <$> pickLeaderWithPointerHuman
-  MemberCycleForwardLevel -> Left <$> memberCycleLevelHuman
-  MemberCycleForward -> Left <$> memberCycleHuman
+  MemberCycleForwardLevel -> Left <$> memberCycleLevelHuman True
+  MemberCycleForward -> Left <$> memberCycleHuman True
   SelectActor -> addNoError selectActorHuman
   SelectNone -> addNoError selectNoneHuman
   SelectWithPointer -> Left <$> selectWithPointerHuman

--- a/engine-src/Game/LambdaHack/Client/UI/HumanCmd.hs
+++ b/engine-src/Game/LambdaHack/Client/UI/HumanCmd.hs
@@ -154,8 +154,8 @@ data HumanCmd =
   | ChooseItemApply [TriggerItem]
   | PickLeader Int
   | PickLeaderWithPointer
-  | MemberCycle
-  | MemberBack
+  | MemberCycleForward
+  | MemberCycleForwardLevel
   | SelectActor
   | SelectNone
   | SelectWithPointer

--- a/engine-src/Game/LambdaHack/Client/UI/HumanCmd.hs
+++ b/engine-src/Game/LambdaHack/Client/UI/HumanCmd.hs
@@ -4,6 +4,7 @@ module Game.LambdaHack.Client.UI.HumanCmd
   ( CmdCategory(..), categoryDescription
   , CmdArea(..), areaDescription
   , CmdTriple, AimModeCmd(..), HumanCmd(..)
+  , CycleDirection(..)
   , TriggerItem(..)
   ) where
 
@@ -154,10 +155,8 @@ data HumanCmd =
   | ChooseItemApply [TriggerItem]
   | PickLeader Int
   | PickLeaderWithPointer
-  | MemberCycleForward
-  | MemberCycleBackward
-  | MemberCycleForwardLevel
-  | MemberCycleBackwardLevel
+  | MemberCycle CycleDirection
+  | MemberCycleLevel CycleDirection
   | SelectActor
   | SelectNone
   | SelectWithPointer
@@ -197,6 +196,13 @@ data HumanCmd =
 instance NFData HumanCmd
 
 instance Binary HumanCmd
+
+data CycleDirection = Forward | Backward
+  deriving (Show, Read, Eq, Ord, Generic)
+
+instance NFData CycleDirection
+
+instance Binary CycleDirection
 
 -- | Description of how item manipulation is triggered and communicated
 -- to the player.

--- a/engine-src/Game/LambdaHack/Client/UI/HumanCmd.hs
+++ b/engine-src/Game/LambdaHack/Client/UI/HumanCmd.hs
@@ -155,7 +155,9 @@ data HumanCmd =
   | PickLeader Int
   | PickLeaderWithPointer
   | MemberCycleForward
+  | MemberCycleBackward
   | MemberCycleForwardLevel
+  | MemberCycleBackwardLevel
   | SelectActor
   | SelectNone
   | SelectWithPointer

--- a/engine-src/Game/LambdaHack/Client/UI/HumanCmd.hs
+++ b/engine-src/Game/LambdaHack/Client/UI/HumanCmd.hs
@@ -4,7 +4,6 @@ module Game.LambdaHack.Client.UI.HumanCmd
   ( CmdCategory(..), categoryDescription
   , CmdArea(..), areaDescription
   , CmdTriple, AimModeCmd(..), HumanCmd(..)
-  , CycleDirection(..)
   , TriggerItem(..)
   ) where
 
@@ -155,8 +154,8 @@ data HumanCmd =
   | ChooseItemApply [TriggerItem]
   | PickLeader Int
   | PickLeaderWithPointer
-  | MemberCycle CycleDirection
-  | MemberCycleLevel CycleDirection
+  | MemberCycle Direction
+  | MemberCycleLevel Direction
   | SelectActor
   | SelectNone
   | SelectWithPointer
@@ -183,7 +182,7 @@ data HumanCmd =
   | AimEnemy
   | AimItem
   | AimAscend Int
-  | EpsIncr Bool
+  | EpsIncr Direction 
   | XhairUnknown
   | XhairItem
   | XhairStair Bool
@@ -196,13 +195,6 @@ data HumanCmd =
 instance NFData HumanCmd
 
 instance Binary HumanCmd
-
-data CycleDirection = Forward | Backward
-  deriving (Show, Read, Eq, Ord, Generic)
-
-instance NFData CycleDirection
-
-instance Binary CycleDirection
 
 -- | Description of how item manipulation is triggered and communicated
 -- to the player.

--- a/engine-src/Game/LambdaHack/Client/UI/InventoryM.hs
+++ b/engine-src/Game/LambdaHack/Client/UI/InventoryM.hs
@@ -330,7 +330,7 @@ transition psuit prompt promptGeneric permitMulitple
           in (km, useMultipleDef $ Right km)
         , let km = K.mkChar '!'
           in (km, useMultipleDef $ Left "")  -- alias close to 'g'
-        , let km = revCmd MemberCycle
+        , let km = revCmd MemberCycleForwardLevel
           in (km, DefItemKey
            { defLabel = Right km
            , defCond = maySwitchLeader cCur
@@ -340,12 +340,12 @@ transition psuit prompt promptGeneric permitMulitple
                let !_A = assert (isNothing err `blame` err) ()
                recCall numPrefix cCur cRest itemDialogState
            })
-        , let km = revCmd MemberBack
+        , let km = revCmd MemberCycleForward
           in (km, DefItemKey
            { defLabel = Right km
            , defCond = maySwitchLeader cCur && not (autoDun || null hs)
            , defAction = \_ -> do
-               err <- memberBack False
+               err <- memberCycle False
                let !_A = assert (isNothing err `blame` err) ()
                recCall numPrefix cCur cRest itemDialogState
            })

--- a/engine-src/Game/LambdaHack/Client/UI/InventoryM.hs
+++ b/engine-src/Game/LambdaHack/Client/UI/InventoryM.hs
@@ -336,7 +336,7 @@ transition psuit prompt promptGeneric permitMulitple
            , defCond = maySwitchLeader cCur
                        && any (\(_, b, _) -> blid b == blid body) hs
            , defAction = \_ -> do
-               err <- memberCycle False
+               err <- memberCycleLevel False True
                let !_A = assert (isNothing err `blame` err) ()
                recCall numPrefix cCur cRest itemDialogState
            })
@@ -345,7 +345,7 @@ transition psuit prompt promptGeneric permitMulitple
            { defLabel = Right km
            , defCond = maySwitchLeader cCur && not (autoDun || null hs)
            , defAction = \_ -> do
-               err <- memberCycle False
+               err <- memberCycle False True
                let !_A = assert (isNothing err `blame` err) ()
                recCall numPrefix cCur cRest itemDialogState
            })

--- a/engine-src/Game/LambdaHack/Client/UI/InventoryM.hs
+++ b/engine-src/Game/LambdaHack/Client/UI/InventoryM.hs
@@ -330,7 +330,7 @@ transition psuit prompt promptGeneric permitMulitple
           in (km, useMultipleDef $ Right km)
         , let km = K.mkChar '!'
           in (km, useMultipleDef $ Left "")  -- alias close to 'g'
-        , let km = revCmd MemberCycleForwardLevel
+        , let km = revCmd $ MemberCycleLevel Forward
           in (km, DefItemKey
            { defLabel = Right km
            , defCond = maySwitchLeader cCur
@@ -340,7 +340,7 @@ transition psuit prompt promptGeneric permitMulitple
                let !_A = assert (isNothing err `blame` err) ()
                recCall numPrefix cCur cRest itemDialogState
            })
-        , let km = revCmd MemberCycleForward
+        , let km = revCmd $ MemberCycle Forward
           in (km, DefItemKey
            { defLabel = Right km
            , defCond = maySwitchLeader cCur && not (autoDun || null hs)


### PR DESCRIPTION
As discussed in issue #206 this branch aims to slightly change how cycling through teammates works. So far the first three points in the issue have been implemented, whereas the fourth optional task remains.

 > (Optional) Add the new shift behavior restricted to teammates on a level. Here you should be able to switch through teammates, and change the direction of selection with shift, but only for the teammates on the current level. This would be done with the binding Alt+Shift-Tab

Because Alt+Shift+Tab isn't defined as a Key type yet in Key.hs, adding it would maybe require some additional work such as translating the Alt+Shift+Tab key code to the type in Sdl.hs