### PR TITLE
Add fullscreen CLI option for SDL renderer

### DIFF
--- a/engine-src/Game/LambdaHack/Client/UI/Frontend/Sdl.hs
+++ b/engine-src/Game/LambdaHack/Client/UI/Frontend/Sdl.hs
@@ -189,7 +189,9 @@ startupFun coscreen soptions@ClientOptions{..} rfMVar = do
   SDL.initialize [SDL.InitVideo]
   let screenV2 = SDL.V2 (toEnum $ rwidth coscreen * boxSize)
                         (toEnum $ rheight coscreen * boxSize)
-      windowConfig = SDL.defaultWindow {SDL.windowInitialSize = screenV2}
+      windowConfig = SDL.defaultWindow
+        { SDL.windowInitialSize = screenV2
+        , SDL.windowMode = if sfullscreen then SDL.Fullscreen else SDL.Windowed }
       rendererConfig = SDL.RendererConfig
         { rendererType          = if sbenchmark
                                   then SDL.AcceleratedRenderer
@@ -198,6 +200,7 @@ startupFun coscreen soptions@ClientOptions{..} rfMVar = do
         }
   swindow <- SDL.createWindow title windowConfig
   srenderer <- SDL.createRenderer swindow (-1) rendererConfig
+  when sfullscreen (SDL.rendererLogicalSize srenderer SDL.$= Just screenV2)
   -- Display black screen ASAP to hide any garbage.
   SDL.rendererRenderTarget srenderer SDL.$= Nothing
   SDL.clear srenderer  -- clear the backbuffer

--- a/engine-src/Game/LambdaHack/Common/ClientOptions.hs
+++ b/engine-src/Game/LambdaHack/Common/ClientOptions.hs
@@ -23,6 +23,8 @@ data ClientOptions = ClientOptions
       -- ^ Available fonts as defined in config file.
   , sfontsets         :: [(Text, FontSet)]
       -- ^ Available font sets as defined in config file.
+  , sfullscreen       :: Bool
+      -- ^ Whether to start in fullscreen mode --
   , slogPriority      :: Maybe Int
       -- ^ How much to log (e.g., from SDL). 1 is all, 5 is errors, the default.
   , smaxFps           :: Maybe Double
@@ -69,6 +71,7 @@ defClientOptions = ClientOptions
   , sallFontsScale = Nothing
   , sfonts = []
   , sfontsets = []
+  , sfullscreen = False
   , slogPriority = Nothing
   , smaxFps = Nothing
   , sdisableAutoYes = False

--- a/engine-src/Game/LambdaHack/Server/Commandline.hs
+++ b/engine-src/Game/LambdaHack/Server/Commandline.hs
@@ -45,7 +45,7 @@ serverOptionsP :: Parser ServerOptions
 serverOptionsP = do
   ~(snewGameSer, scurChalSer)
                     <- serToChallenge <$> newGameP
-  sfullscreenSer    <- fullscreenP
+  sfullscreen       <- fullscreenP
   knowMap           <- knowMapP
   knowEvents        <- knowEventsP
   knowItems         <- knowItemsP
@@ -87,7 +87,6 @@ serverOptionsP = do
       sclientOptions = ClientOptions
         { sfonts         = []  -- comes only from config file
         , sfontsets      = []  -- comes only from config file
-        , sfullscreen    = sfullscreenSer
         , stitle         = Nothing
         , snewGameCli    = snewGameSer
         , ssavePrefixCli = ssavePrefixSer

--- a/engine-src/Game/LambdaHack/Server/Commandline.hs
+++ b/engine-src/Game/LambdaHack/Server/Commandline.hs
@@ -45,6 +45,7 @@ serverOptionsP :: Parser ServerOptions
 serverOptionsP = do
   ~(snewGameSer, scurChalSer)
                     <- serToChallenge <$> newGameP
+  sfullscreenSer    <- fullscreenP
   knowMap           <- knowMapP
   knowEvents        <- knowEventsP
   knowItems         <- knowItemsP
@@ -86,6 +87,7 @@ serverOptionsP = do
       sclientOptions = ClientOptions
         { sfonts         = []  -- comes only from config file
         , sfontsets      = []  -- comes only from config file
+        , sfullscreen    = sfullscreenSer
         , stitle         = Nothing
         , snewGameCli    = snewGameSer
         , ssavePrefixCli = ssavePrefixSer
@@ -183,6 +185,12 @@ newGameP = optional $ max 1 <$> min difficultyBound <$>
   option auto (  long "newGame"
               <> help "Start a new game, overwriting the save file, with difficulty for all UI players set to N"
               <> metavar "N" )
+
+fullscreenP :: Parser Bool
+fullscreenP =
+  switch (  long "fullscreen"
+         <> short 'f'
+         <> help "Start game in fullscreen mode (currently, only implemented for the SDL renderer)" )
 
 stopAfterSecsP :: Parser (Maybe Int)
 stopAfterSecsP = optional $ max 0 <$>

--- a/engine-src/Game/LambdaHack/Server/Commandline.hs
+++ b/engine-src/Game/LambdaHack/Server/Commandline.hs
@@ -190,7 +190,7 @@ fullscreenP :: Parser Bool
 fullscreenP =
   switch (  long "fullscreen"
          <> short 'f'
-         <> help "Start game in fullscreen mode (currently, only implemented for the SDL renderer)" )
+         <> help "Start game in fullscreen mode" )
 
 stopAfterSecsP :: Parser (Maybe Int)
 stopAfterSecsP = optional $ max 0 <$>


### PR DESCRIPTION
Better way to do this would likely be to override the font scale when in fullscreen mode. This way, we can automatically change the font scale a good setting. However, the current results look great to me in 1080p with 1.5 font scale.

Related #221